### PR TITLE
Improve priority efficiency

### DIFF
--- a/team_formation/app/team_generator/algorithm/priority_algorithm/priority.py
+++ b/team_formation/app/team_generator/algorithm/priority_algorithm/priority.py
@@ -1,3 +1,6 @@
+from typing import List
+
+from team_formation.app.team_generator.student import Student
 from team_formation.app.team_generator.team import Team
 
 
@@ -38,9 +41,9 @@ class Priority:
             raise ValueError('Limit must be greater than 0')
         raise NotImplementedError()
 
-    def satisfied_by(self, team: Team) -> bool:
+    def satisfied_by(self, students: List[Student]) -> bool:
         count = 0
-        for student in team.students:
+        for student in students:
             if self.skill_id in student.skills:
                 count += self.value in student.skills[self.skill_id]
         return self.student_count_meets_limit(count)

--- a/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
+++ b/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
@@ -77,17 +77,14 @@ class PriorityAlgorithm(WeightAlgorithm):
             for team_set in team_sets:
                 new_team_sets += self.mutate(team_set)
             team_sets = new_team_sets + team_sets
-            # TODO: explicitly sort them (but is this faster than pri queue approach?)
             team_sets = sorted(team_sets, key=lambda ts: ts.calculate_score(self.priorities, self.student_dict), reverse=True)
-            # TODO: then slice to MAX_KEEP
-            # team_sets = nlargest(self.MAX_KEEP, team_sets)
             team_sets = team_sets[:self.MAX_KEEP]
-            # print(f'Iteration: {iteration} | {[team_set.score for team_set in team_sets]}')
+            print(f'Iteration: {iteration} | {[team_set.score for team_set in team_sets]}')
             iteration += 1
 
-        print(iteration)
+        print(f'Total iterations: {iteration}')
+        print(f'Scores: {[team_set.score for team_set in team_sets]}')
         return self.save_team_compositions_to_teams(team_sets[0])
-        # return heappop(team_sets).teams  # TODO: grab index 0
 
     def save_team_compositions_to_teams(self, priority_team_set: PriorityTeamSet) -> List[Team]:
         teams: List[Team] = []

--- a/team_formation/app/team_generator/algorithm/priority_algorithm/priority_teamset.py
+++ b/team_formation/app/team_generator/algorithm/priority_algorithm/priority_teamset.py
@@ -1,80 +1,44 @@
 import copy
 from math import floor
-from typing import List
+from typing import List, Dict
 from team_formation.app.team_generator.algorithm.priority_algorithm.priority import Priority
+from team_formation.app.team_generator.algorithm.priority_algorithm.scoring import get_priority_satisfaction_array, \
+    get_multipliers
+from team_formation.app.team_generator.student import Student
 from team_formation.app.team_generator.team import Team
 
 
+class PriorityTeam:
+    team: Team = None  # just a reference to the team so team requirements can be found easily without duplicating them
+    student_ids: List[int]
+
+    def __init__(self, team: Team, student_ids: List[int]):
+        self.team = team
+        self.student_ids = student_ids
+
+
 class PriorityTeamSet:
-    teams: List[Team] = []
-    priorities: List[Priority] = []
-    NUM_BUCKETS: int = 25
+    priority_teams: List[PriorityTeam] = []
 
-    def __init__(self, teams: List[Team], priorities: List[Priority]):
-        self.teams = teams
-        self.priorities = priorities
-        self.score = self.calculate_score()
-
-    def __lt__(self, other: 'PriorityTeamSet'):
-        return self.score < other.score
-
-    def __gt__(self, other: 'PriorityTeamSet'):
-        return self.score > other.score
-
-    def __lte__(self, other):
-        return not self.__gt__(other)
-
-    def __gte__(self, other):
-        return not self.__lt__(other)
+    def __init__(self, priority_teams: List[PriorityTeam]):
+        self.priority_teams = priority_teams
+        self.score = None  # not calculated yet
 
     def clone(self):
         # TODO: keep an eye on this copying properly
-        cloned_teams = [team.clone() for team in self.teams]
-        return PriorityTeamSet(teams=cloned_teams, priorities=self.priorities)
+        cloned_priority_teams = copy.deepcopy(self.priority_teams)
+        return PriorityTeamSet(priority_teams=cloned_priority_teams)
 
-    def get_priority_satisfaction_array(self) -> List[int]:
-        return [self.get_priority_satisfaction(priority) for priority in self.priorities]
+    def calculate_score(self, priorities: List[Priority], student_dict: Dict[int, Student]) -> float:
+        if self.score:
+            return self.score
 
-    def get_priority_satisfaction(self, priority: Priority) -> int:
-        satisfaction_ratio = self.satisfaction_ratio(priority)
-        if satisfaction_ratio == 0:
-            return 0
-        if satisfaction_ratio == 1:
-            return self.NUM_BUCKETS - 1
-
-        return min(
-            floor(satisfaction_ratio * self.NUM_BUCKETS),
-            self.NUM_BUCKETS - 1
-        )
-
-    def satisfaction_ratio(self, priority: Priority) -> float:
-        # returns value in [0, 1] IMPORTANT that it does this, satisfaction value relies on it
-        count = 0
-        for team in self.teams:
-            count += priority.satisfied_by(team)
-        return count / len(self.teams)
-
-    def calculate_score(self) -> float:
-        priority_satisfaction_array = self.get_priority_satisfaction_array()
-        multipliers = get_multipliers(self.priorities, self.NUM_BUCKETS)
-
-        return sum(
+        priority_satisfaction_array = get_priority_satisfaction_array(self.priority_teams, priorities, student_dict)
+        multipliers = get_multipliers(priorities)
+        score = sum(
             [satisfaction * multiplier for satisfaction, multiplier in zip(priority_satisfaction_array, multipliers)]
         )
+        self.score = score
+        return self.score
 
-
-def get_multipliers(priorities: List[Priority], num_buckets: int) -> List[int]:
-    # with 2 buckets and [C1, C2, C3], returns [4, 2, 1]
-    multipliers = [num_buckets ** (n - 1)
-                   for n in range(1, len(priorities) + 1)]
-    return multipliers[::-1]
-
-
-def compare_arrays(first, second):
-    counter = 0
-    while counter < len(first) and counter < len(second):
-        comparison = first[counter] - second[counter]
-        if comparison != 0:
-            return comparison
-        counter += 1
-    return 0
+    # def get_teams(self, student_dict: Dict[int, Student]) -> List[Team]:

--- a/team_formation/app/team_generator/algorithm/priority_algorithm/scoring.py
+++ b/team_formation/app/team_generator/algorithm/priority_algorithm/scoring.py
@@ -1,0 +1,42 @@
+from math import floor
+from typing import List, Dict
+
+from team_formation.app.team_generator.algorithm.priority_algorithm.priority import Priority
+from team_formation.app.team_generator.student import Student
+
+NUM_BUCKETS = 25
+
+
+def get_priority_satisfaction_array(priority_teams: [], priorities: List[Priority],
+                                    student_dict: Dict[int, Student]) -> List[int]:
+    return [get_priority_satisfaction(priority_teams, priority, student_dict) for priority in priorities]
+
+
+def get_priority_satisfaction(priority_teams: [], priority: Priority,
+                              student_dict: Dict[int, Student]) -> int:
+    satisfaction_ratio = get_satisfaction_ratio(priority_teams, priority, student_dict)
+    if satisfaction_ratio == 0:
+        return 0
+    if satisfaction_ratio == 1:
+        return NUM_BUCKETS - 1
+
+    return min(
+        floor(satisfaction_ratio * NUM_BUCKETS),
+        NUM_BUCKETS - 1
+    )
+
+
+def get_satisfaction_ratio(priority_teams: [], priority: Priority,
+                           student_dict: Dict[int, Student]) -> float:
+    # returns value in [0, 1] IMPORTANT that it does this, satisfaction value relies on it
+    count = 0
+    for priority_team in priority_teams:
+        count += priority.satisfied_by([student_dict[student_id] for student_id in priority_team.student_ids])
+    return count / len(priority_teams)
+
+
+def get_multipliers(priorities: List[Priority]) -> List[int]:
+    # with 2 buckets and [C1, C2, C3], returns [4, 2, 1]
+    multipliers = [NUM_BUCKETS ** (n - 1)
+                   for n in range(1, len(priorities) + 1)]
+    return multipliers[::-1]

--- a/test_priority.py
+++ b/test_priority.py
@@ -11,14 +11,23 @@ if __name__ == '__main__':
         priorities=[
             {
                 'order': 1,
+                'constraint': Priority.TYPE_CONCENTRATE,
+                'skill_id': 73,  # timeslot availability
+                'limit_option': Priority.MAX_OF,
+                'limit': 2,
+                'value': 3,  # some timeslot
+            },
+            {
+                'order': 1,
                 'constraint': Priority.TYPE_DIVERSIFY,
-                'skill_id': 73,
+                'skill_id': 81,  # gender
                 'limit_option': Priority.MIN_OF,
                 'limit': 2,
-                'value': 3,
+                'value': 2,  # female
             }
         ],
-        diversify_options=[{'id': 73}]
+        diversify_options=[{'id': 81}],
+        concentrate_options=[{'id': 73}]
     )
     teams = mock_generation(PriorityAlgorithm, algorithm_options, logger, 56, DATA_FILE_PATH)
     logger.end()


### PR DESCRIPTION
Before we were reaching 16 iterations in 30s (2 priorities, using real dataset)
- The slowness largely comes from how long it takes to deepcopy team compositions

By making the actual data stored in a priority team set more lightweight, we triple this to 55 iterations in 30s

Further improvements can still be made, like:
- `PriorityTeam` can store a hash of booleans for each priority so checking if a team satisfies is only recalculated if the team is different somehow (needs to be done very delicately)