### PR TITLE
run algorithms in parallel

### DIFF
--- a/old/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
+++ b/old/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
@@ -20,8 +20,8 @@ class PriorityAlgorithm(WeightAlgorithm):
 
     MAX_KEEP: int = 3  # nodes
     MAX_SPREAD: int = 3  # nodes
-    MAX_ITERATE: int = 15  # times
-    MAX_TIME: int = 30  # seconds
+    MAX_ITERATE: int = 1500  # times
+    MAX_TIME: int = 7  # seconds
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/old/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
+++ b/old/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
@@ -20,8 +20,8 @@ class PriorityAlgorithm(WeightAlgorithm):
 
     MAX_KEEP: int = 3  # nodes
     MAX_SPREAD: int = 3  # nodes
-    MAX_ITERATE: int = 1500  # times
-    MAX_TIME: int = 7  # seconds
+    MAX_ITERATE: int = 1000  # times
+    MAX_TIME: int = 1  # seconds
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Goals:
- uses the `threading` library to run each algorithm in parallel (per trial)
- allows us to up some of the default parameters on the priority algorithm (so it has more of a chance to actually do things)

Validated:
- Ran a run in parallel and in sequence, as expected, the sequential simulation took twice as long
Rationale: priority and priority_new take the longest (by far) to run and we run both so parallel saved us the exact amount of time that the extra generation from priority was causing

closes #81 