### PR TITLE
early work for algorithm config support

### DIFF
--- a/api/ai/new/interfaces/algorithm.py
+++ b/api/ai/new/interfaces/algorithm.py
@@ -14,7 +14,7 @@ class Algorithm(ABC):
         self,
         algorithm_options: AlgorithmOptions,
         team_generation_options: TeamGenerationOptions,
-            algorithm_config: AlgorithmConfig = None,
+        algorithm_config: AlgorithmConfig = None,
     ):
         self.algorithm_options: AlgorithmOptions = algorithm_options
         self.team_generation_options: TeamGenerationOptions = team_generation_options

--- a/api/ai/new/interfaces/algorithm.py
+++ b/api/ai/new/interfaces/algorithm.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Tuple, Optional
 
+from api.ai.new.interfaces.algorithm_config import AlgorithmConfig
 from api.ai.new.interfaces.algorithm_options import AlgorithmOptions
 from api.ai.new.interfaces.team_generation_options import TeamGenerationOptions
 from api.models.student import Student
@@ -13,9 +14,11 @@ class Algorithm(ABC):
         self,
         algorithm_options: AlgorithmOptions,
         team_generation_options: TeamGenerationOptions,
+            algorithm_config: AlgorithmConfig = None,
     ):
         self.algorithm_options: AlgorithmOptions = algorithm_options
         self.team_generation_options: TeamGenerationOptions = team_generation_options
+        self.algorithm_config: AlgorithmConfig = algorithm_config
         self.teams: List[Team] = []
 
     @abstractmethod

--- a/api/ai/new/interfaces/algorithm_config.py
+++ b/api/ai/new/interfaces/algorithm_config.py
@@ -8,6 +8,7 @@ class AlgorithmConfig(ABC):
 
     i.e. The maximum amount of time an algorithm is allowed to run for is a config choice, not an options choice.
     """
+
     def __post_init__(self):
         self.validate()
 

--- a/api/ai/new/interfaces/algorithm_config.py
+++ b/api/ai/new/interfaces/algorithm_config.py
@@ -1,0 +1,36 @@
+from abc import ABC, abstractmethod
+
+
+class AlgorithmConfig(ABC):
+    """
+    An algorithm config is semantically different from AlgorithmOptions.
+    AlgorithmConfig specifies underlying constants and internals that are largely set by developers, not the user.
+
+    i.e. The maximum amount of time an algorithm is allowed to run for is a config choice, not an options choice.
+    """
+    def __post_init__(self):
+        self.validate()
+
+    @abstractmethod
+    def validate(self):
+        pass
+
+
+class RandomAlgorithmConfig(AlgorithmConfig):
+    def validate(self):
+        super().validate()
+
+
+class WeightAlgorithmConfig(AlgorithmConfig):
+    def validate(self):
+        super().validate()
+
+
+class SocialAlgorithmConfig(AlgorithmConfig):
+    def validate(self):
+        super().validate()
+
+
+class PriorityAlgorithmConfig(AlgorithmConfig):
+    def validate(self):
+        super().validate()

--- a/api/ai/new/interfaces/algorithm_options.py
+++ b/api/ai/new/interfaces/algorithm_options.py
@@ -10,6 +10,7 @@ class AlgorithmOptions(ABC):
     An algorithm option is semantically different from AlgorithmConfig.
     AlgorithmOptions specifies the customizable aspects of an algorithm made available for users to specify to their needs.
     """
+
     def __post_init__(self):
         self.validate()
 

--- a/api/ai/new/interfaces/algorithm_options.py
+++ b/api/ai/new/interfaces/algorithm_options.py
@@ -6,6 +6,10 @@ from api.models.enums import RelationshipBehaviour
 
 
 class AlgorithmOptions(ABC):
+    """
+    An algorithm option is semantically different from AlgorithmConfig.
+    AlgorithmOptions specifies the customizable aspects of an algorithm made available for users to specify to their needs.
+    """
     def __post_init__(self):
         self.validate()
 

--- a/api/ai/new/random_algorithm/random_algorithm.py
+++ b/api/ai/new/random_algorithm/random_algorithm.py
@@ -2,11 +2,15 @@ from random import randint
 from typing import List, Tuple, Optional, cast
 
 from api.ai.new.interfaces.algorithm import ChooseAlgorithm
+from api.ai.new.interfaces.algorithm_config import RandomAlgorithmConfig
 from api.ai.new.interfaces.algorithm_options import RandomAlgorithmOptions
 from api.ai.new.utils import generate_with_choose
 from api.models.student import Student
 from api.models.team import Team
 from api.models.team_set import TeamSet
+
+
+DEFAULT_RANDOM_ALGORITHM_CONFIG = RandomAlgorithmConfig()
 
 
 class RandomAlgorithm(ChooseAlgorithm):
@@ -15,6 +19,12 @@ class RandomAlgorithm(ChooseAlgorithm):
         self.algorithm_options: RandomAlgorithmOptions = cast(
             RandomAlgorithmOptions, self.algorithm_options
         )
+        if self.algorithm_config:
+            self.algorithm_config: RandomAlgorithmConfig = cast(
+                RandomAlgorithmConfig, self.algorithm_config
+            )
+        else:
+            self.algorithm_config = DEFAULT_RANDOM_ALGORITHM_CONFIG
 
     def generate(self, students: List[Student]) -> TeamSet:
         return generate_with_choose(self, students, self.teams)

--- a/api/ai/new/weight_algorithm/weight_algorithm.py
+++ b/api/ai/new/weight_algorithm/weight_algorithm.py
@@ -1,11 +1,14 @@
 from typing import List, Tuple, Optional, cast
 
 from api.ai.new.interfaces.algorithm import ChooseAlgorithm
+from api.ai.new.interfaces.algorithm_config import WeightAlgorithmConfig
 from api.ai.new.interfaces.algorithm_options import WeightAlgorithmOptions
 from api.ai.new.utils import generate_with_choose
 from api.models.student import Student
 from api.models.team import Team
 from api.models.team_set import TeamSet
+
+DEFAULT_WEIGHT_ALGORITHM_CONFIG = WeightAlgorithmConfig()
 
 
 class WeightAlgorithm(ChooseAlgorithm):
@@ -14,6 +17,12 @@ class WeightAlgorithm(ChooseAlgorithm):
         self.algorithm_options: WeightAlgorithmOptions = cast(
             WeightAlgorithmOptions, self.algorithm_options
         )
+        if self.algorithm_config:
+            self.algorithm_config: WeightAlgorithmConfig = cast(
+                WeightAlgorithmConfig, self.algorithm_config
+            )
+        else:
+            self.algorithm_config = DEFAULT_WEIGHT_ALGORITHM_CONFIG
 
     def generate(self, students: List[Student]) -> TeamSet:
         return generate_with_choose(self, students, self.teams)


### PR DESCRIPTION
related to #108 

Adds this structure for the reimplementation of the algorithms
Comments in the code specify, but tldr Configs exist so we can augment how algorithms actually behave and they are not something to be customized by end users, but eventually there will be a simple way to overwrite these configs within a simulation for benchmarking purposes