### PR TITLE
add proper project preferences support

### DIFF
--- a/api/models/enums.py
+++ b/api/models/enums.py
@@ -59,7 +59,6 @@ class ScenarioAttribute(Enum):
     MAJOR = 5
     YEAR_LEVEL = 6
     TIMESLOT_AVAILABILITY = 7
-    PROJECT_PREFERENCES = 8
 
 
 class AttributeValueEnum(Enum):

--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -11,6 +11,7 @@ from benchmarking.data.interfaces import (
     AttributeRangeConfig,
     NumValuesConfig,
 )
+from utils.validation import is_non_negative_integer, is_unique
 
 
 @dataclass
@@ -18,9 +19,45 @@ class MockStudentProviderSettings:
     number_of_students: int
     attribute_ranges: Dict[int, AttributeRangeConfig] = field(default_factory=dict)
     num_values_per_attribute: Dict[int, NumValuesConfig] = field(default_factory=dict)
+    # ids of projects that can be selected as a preference by students
+    project_preference_options: List[int] = field(default_factory=list)
+    num_project_preferences_per_student: int = 0
     number_of_friends: int = 0
     number_of_enemies: int = 0
     friend_distribution: Literal["cluster", "random"] = "random"
+
+    def __post_init__(self):
+        self.validate()
+
+    def validate(self):
+        #todo: add validation for attribute_ranges vs num_values_per_attribute
+        if not is_non_negative_integer(self.number_of_students):
+            raise ValueError(
+                f"number_of_students ({self.number_of_students}) must be a non-negative integer."
+            )
+        if not is_non_negative_integer(self.number_of_friends):
+            raise ValueError(
+                f"number_of_friends ({self.number_of_friends}) must be a non-negative integer."
+            )
+        if not is_non_negative_integer(self.number_of_enemies):
+            raise ValueError(
+                f"number_of_enemies ({self.number_of_enemies}) must be a non-negative integer."
+            )
+        if (
+                len(self.project_preference_options)
+                < self.num_project_preferences_per_student
+        ):
+            raise ValueError(
+                f"num_project_preferences_per_student ({self.num_project_preferences_per_student}) cannot "
+                "be > the number of project options."
+            )
+        if not is_non_negative_integer(self.num_project_preferences_per_student):
+            raise ValueError(
+                f"num_project_preferences_per_student ({self.num_project_preferences_per_student}) must be a "
+                f"non-negative integer."
+            )
+        if not is_unique(self.project_preference_options):
+            raise ValueError(f"project_preference_options must be unique if specified.")
 
 
 class MockStudentProvider(StudentProvider):
@@ -35,6 +72,8 @@ class MockStudentProvider(StudentProvider):
             self.settings.friend_distribution,
             self.settings.attribute_ranges,
             self.settings.num_values_per_attribute,
+            self.settings.project_preference_options,
+            self.settings.num_project_preferences_per_student,
         )
         # the students must be shuffled here because certain algorithms
         #   perform better/worse based on the ordering of students.
@@ -48,27 +87,18 @@ class MockStudentProvider(StudentProvider):
 
     @property
     def max_project_preferences_per_student(self) -> int:
-        num_values_config: NumValuesConfig = self.settings.num_values_per_attribute.get(
-            ScenarioAttribute.PROJECT_PREFERENCES.value,
-            None,
-        )
-
-        if isinstance(num_values_config, int):
-            return num_values_config
-
-        if isinstance(num_values_config, tuple):
-            return num_values_config[1]
-
-        return 0
+        return self.settings.num_project_preferences_per_student
 
 
 def create_mock_students(
-    number_of_students: int,
-    number_of_friends: int,
-    number_of_enemies: int,
-    friend_distribution: Literal["cluster", "random"],
-    attribute_ranges: Dict[int, AttributeRangeConfig],
-    num_values_per_attribute: Dict[int, NumValuesConfig],
+        number_of_students: int,
+        number_of_friends: int,
+        number_of_enemies: int,
+        friend_distribution: Literal["cluster", "random"],
+        attribute_ranges: Dict[int, AttributeRangeConfig],
+        num_values_per_attribute: Dict[int, NumValuesConfig],
+        project_preference_options: List[int],
+        num_project_preferences_per_student: int,
 ) -> List[Student]:
     students = []
     n = number_of_students
@@ -100,11 +130,18 @@ def create_mock_students(
                 attribute_range_config, num_values
             )
 
+        project_preferences = None
+        if project_preference_options and num_project_preferences_per_student:
+            project_preferences = random_choice(
+                project_preference_options, num_project_preferences_per_student
+            )
+
         students.append(
             Student(
                 i,
                 relationships=relationships,
                 attributes=attributes,
+                project_preferences=project_preferences or [],
             )
         )
     return students
@@ -119,7 +156,7 @@ def num_values_for_attribute(num_values_config: NumValuesConfig) -> int:
 
 
 def random_choice(
-    possible_values: List, size=None, replace=False, weights=None
+        possible_values: List, size=None, replace=False, weights=None
 ) -> List[int]:
     """
     Uses np.random.choice() but always returns a list of int
@@ -133,7 +170,7 @@ def random_choice(
 
 
 def attribute_values_from_range(
-    range_config: AttributeRangeConfig, num_values: Optional[int] = 1
+        range_config: AttributeRangeConfig, num_values: Optional[int] = 1
 ) -> List[int]:
     if isinstance(range_config[0], (int, AttributeValueEnum)):
         if isinstance(range_config[0], int):

--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -30,7 +30,7 @@ class MockStudentProviderSettings:
         self.validate()
 
     def validate(self):
-        #todo: add validation for attribute_ranges vs num_values_per_attribute
+        # todo: add validation for attribute_ranges vs num_values_per_attribute
         if not is_non_negative_integer(self.number_of_students):
             raise ValueError(
                 f"number_of_students ({self.number_of_students}) must be a non-negative integer."
@@ -44,8 +44,8 @@ class MockStudentProviderSettings:
                 f"number_of_enemies ({self.number_of_enemies}) must be a non-negative integer."
             )
         if (
-                len(self.project_preference_options)
-                < self.num_project_preferences_per_student
+            len(self.project_preference_options)
+            < self.num_project_preferences_per_student
         ):
             raise ValueError(
                 f"num_project_preferences_per_student ({self.num_project_preferences_per_student}) cannot "
@@ -91,14 +91,14 @@ class MockStudentProvider(StudentProvider):
 
 
 def create_mock_students(
-        number_of_students: int,
-        number_of_friends: int,
-        number_of_enemies: int,
-        friend_distribution: Literal["cluster", "random"],
-        attribute_ranges: Dict[int, AttributeRangeConfig],
-        num_values_per_attribute: Dict[int, NumValuesConfig],
-        project_preference_options: List[int],
-        num_project_preferences_per_student: int,
+    number_of_students: int,
+    number_of_friends: int,
+    number_of_enemies: int,
+    friend_distribution: Literal["cluster", "random"],
+    attribute_ranges: Dict[int, AttributeRangeConfig],
+    num_values_per_attribute: Dict[int, NumValuesConfig],
+    project_preference_options: List[int],
+    num_project_preferences_per_student: int,
 ) -> List[Student]:
     students = []
     n = number_of_students
@@ -156,7 +156,7 @@ def num_values_for_attribute(num_values_config: NumValuesConfig) -> int:
 
 
 def random_choice(
-        possible_values: List, size=None, replace=False, weights=None
+    possible_values: List, size=None, replace=False, weights=None
 ) -> List[int]:
     """
     Uses np.random.choice() but always returns a list of int
@@ -170,7 +170,7 @@ def random_choice(
 
 
 def attribute_values_from_range(
-        range_config: AttributeRangeConfig, num_values: Optional[int] = 1
+    range_config: AttributeRangeConfig, num_values: Optional[int] = 1
 ) -> List[int]:
     if isinstance(range_config[0], (int, AttributeValueEnum)):
         if isinstance(range_config[0], int):

--- a/benchmarking/simulation/basic_simulation_set.py
+++ b/benchmarking/simulation/basic_simulation_set.py
@@ -12,6 +12,7 @@ from benchmarking.data.interfaces import (
 )
 from benchmarking.evaluations.interfaces import Scenario, TeamSetMetric
 from benchmarking.simulation.algorithm_translator import AlgorithmTranslator
+from benchmarking.simulation.simulation_settings import SimulationSettings
 from old.team_formation.app.team_generator.algorithm.algorithms import AlgorithmOptions
 
 RunOutput = Dict[AlgorithmType, Dict[str, List[float]]]
@@ -52,16 +53,15 @@ class BasicSimulationSet:
             raise ValueError(
                 "If you override algorithm_types, you must specify at least 1 algorithm type to run a simulation."
             )
-        if self.num_teams and self.initial_teams_provider:
-            raise ValueError(
-                "Either specify num_teams OR give a project initial_teams_provider, not both."
-            )
-        if not self.num_teams and not self.initial_teams_provider:
-            raise ValueError(
-                "Either num_teams OR a project initial_teams_provider must be specified."
-            )
-        if not self.metrics:
-            raise ValueError("At least one metric must be specified for a simulation.")
+
+        # fixme: temporary: creates this object so we get all the validations there for free
+        SimulationSettings(
+            num_teams=num_teams,
+            student_provider=student_provider,
+            metrics=metrics,
+            initial_teams_provider=initial_teams_provider,
+            scenario=scenario,
+        )
 
         self.run_outputs = defaultdict(dict)
         self.algorithm_options: Dict[AlgorithmType, Union[None, AlgorithmOptions]] = {}

--- a/benchmarking/simulation/basic_simulation_set_2.py
+++ b/benchmarking/simulation/basic_simulation_set_2.py
@@ -13,6 +13,7 @@ from benchmarking.data.interfaces import (
 )
 from benchmarking.evaluations.interfaces import Scenario, TeamSetMetric
 from benchmarking.simulation.mock_algorithm_2 import MockAlgorithm2
+from benchmarking.simulation.simulation_settings import SimulationSettings
 
 RunOutput = Dict[AlgorithmType, Dict[str, List[float]]]
 
@@ -52,16 +53,15 @@ class BasicSimulationSet2:
             raise ValueError(
                 "If you override algorithm_types, you must specify at least 1 algorithm type to run a simulation."
             )
-        if self.num_teams and self.initial_teams_provider:
-            raise ValueError(
-                "Either specify num_teams OR give a project initial_teams_provider, not both."
-            )
-        if not self.num_teams and not self.initial_teams_provider:
-            raise ValueError(
-                "Either num_teams OR a project initial_teams_provider must be specified."
-            )
-        if not self.metrics:
-            raise ValueError("At least one metric must be specified for a simulation.")
+
+        # fixme: temporary: creates this object so we get all the validations there for free
+        SimulationSettings(
+            num_teams=num_teams,
+            student_provider=student_provider,
+            metrics=metrics,
+            initial_teams_provider=initial_teams_provider,
+            scenario=scenario,
+        )
 
         self.run_outputs = defaultdict(dict)
         self.algorithm_options: Dict[

--- a/benchmarking/simulation/mock_algorithm_2.py
+++ b/benchmarking/simulation/mock_algorithm_2.py
@@ -36,11 +36,12 @@ class MockAlgorithm2:
     def get_team_generation_options(
         num_students: int, num_teams: int, initial_teams: List[TeamShell] = None
     ) -> TeamGenerationOptions:
-        min_team_size = num_students // num_teams
+        _num_teams = len(initial_teams) if initial_teams else num_teams
+        min_team_size = num_students // _num_teams
         return TeamGenerationOptions(
             max_team_size=min_team_size + 1,
             min_team_size=min_team_size,
-            total_teams=num_teams,
+            total_teams=_num_teams,
             initial_teams=initial_teams,
         )
 

--- a/benchmarking/simulation/simulation_settings.py
+++ b/benchmarking/simulation/simulation_settings.py
@@ -3,6 +3,7 @@ from typing import List
 
 from benchmarking.data.interfaces import StudentProvider, InitialTeamsProvider
 from benchmarking.evaluations.interfaces import Scenario, TeamSetMetric
+from utils.validation import assert_can_exist_together
 
 
 @dataclass
@@ -28,3 +29,5 @@ class SimulationSettings:
             )
         if not self.metrics:
             raise ValueError("At least one metric must be specified for a simulation.")
+
+        assert_can_exist_together(self.student_provider, self.initial_teams_provider)

--- a/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
+++ b/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
@@ -9,6 +9,7 @@ from benchmarking.data.simulated_data.mock_student_provider import (
     random_choice,
     MockStudentProviderSettings,
 )
+from utils.validation import is_unique
 
 
 class TestMockStudentProvider(unittest.TestCase):
@@ -20,34 +21,16 @@ class TestMockStudentProvider(unittest.TestCase):
         for student in students:
             self.assertIsInstance(student, Student)
 
-    def test_max_project_preferences_are_correctly_inferred(self):
+    def test_max_project_preferences__are_correctly_inferred(self):
         max_project_preferences_1 = MockStudentProvider(
             MockStudentProviderSettings(
                 number_of_students=10,
-                attribute_ranges={
-                    ScenarioAttribute.PROJECT_PREFERENCES.value: [1, 2, 3, 4],
-                },
-                num_values_per_attribute={
-                    ScenarioAttribute.PROJECT_PREFERENCES.value: 3,
-                },
+                project_preference_options=[1, 2, 3],
+                num_project_preferences_per_student=3,
             )
         ).max_project_preferences_per_student
 
         self.assertEqual(max_project_preferences_1, 3)
-
-        max_project_preferences_2 = MockStudentProvider(
-            MockStudentProviderSettings(
-                number_of_students=10,
-                attribute_ranges={
-                    ScenarioAttribute.PROJECT_PREFERENCES.value: [1, 2, 3, 4],
-                },
-                num_values_per_attribute={
-                    ScenarioAttribute.PROJECT_PREFERENCES.value: (1, 4),
-                },
-            )
-        ).max_project_preferences_per_student
-
-        self.assertEqual(max_project_preferences_2, 4)
 
 
 class TestMockStudentProviderHelpers(unittest.TestCase):
@@ -67,12 +50,30 @@ class TestMockStudentProviderHelpers(unittest.TestCase):
                 2: 2,
                 3: 1,
             },
+            project_preference_options=[],
+            num_project_preferences_per_student=0,
         )
 
         student = students[0]
         self.assertEqual(len(student.attributes[1]), 3)
         self.assertEqual(len(student.attributes[2]), 2)
         self.assertEqual(len(student.attributes[3]), 1)
+
+    def test_create_mock_students__students_have_correct_project_preferences(self):
+        students = create_mock_students(
+            number_of_students=1,
+            number_of_friends=0,
+            number_of_enemies=0,
+            friend_distribution="random",
+            attribute_ranges={},
+            num_values_per_attribute={},
+            project_preference_options=[1, 2, 3],
+            num_project_preferences_per_student=3,
+        )
+
+        student = students[0]
+        self.assertEqual(len(student.project_preferences), 3)
+        self.assertTrue(is_unique(student.project_preferences))
 
     def test_create_mock_students__student_has_num_values_for_attribute_within_range(
         self,
@@ -92,6 +93,8 @@ class TestMockStudentProviderHelpers(unittest.TestCase):
                 2: (1, 3),
                 3: (3, 4),
             },
+            project_preference_options=[],
+            num_project_preferences_per_student=0,
         )
 
         for student in students:
@@ -108,6 +111,8 @@ class TestMockStudentProviderHelpers(unittest.TestCase):
                 friend_distribution="random",
                 attribute_ranges={},
                 num_values_per_attribute={},
+                project_preference_options=[],
+                num_project_preferences_per_student=0,
             )
             for student in students:
                 self.assertGreaterEqual(

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -24,6 +24,9 @@ class TestValidationHelpers(unittest.TestCase):
         self.assertTrue(is_unique(["A", "B"]))
         self.assertFalse(is_unique(["A", "A"]))
 
+        with self.assertRaises(ValueError):
+            is_unique([1, 2, "string"])
+
     def test_is_unique__works_with_dictionaries(self):
         self.assertTrue(is_unique([{"id": 1}, {"id": 2}, {"id": 3}], attr="id"))
         self.assertFalse(is_unique([{"id": 1}, {"id": 1}, {"id": 1}], attr="id"))

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -1,20 +1,82 @@
 import unittest
 
+from api.models.project import Project
 from api.models.student import Student
-from utils.validation import is_unique
+from benchmarking.data.simulated_data.mock_initial_teams_provider import MockInitialTeamsProviderSettings, \
+    MockInitialTeamsProvider
+from benchmarking.data.simulated_data.mock_student_provider import (
+    MockStudentProvider,
+    MockStudentProviderSettings,
+)
+from utils.validation import (
+    is_unique,
+    is_non_negative_integer,
+    assert_can_exist_together,
+)
 
 
 class TestValidationHelpers(unittest.TestCase):
-    def test_validate_unique__works_with_primitives(self):
+    def test_is_unique__works_with_primitives(self):
         self.assertTrue(is_unique([1, 2, 3]))
         self.assertFalse(is_unique([1, 2, 2]))
         self.assertTrue(is_unique(["A", "B"]))
         self.assertFalse(is_unique(["A", "A"]))
 
-    def test_validate_unique__works_with_dictionaries(self):
+    def test_is_unique__works_with_dictionaries(self):
         self.assertTrue(is_unique([{"id": 1}, {"id": 2}, {"id": 3}], attr="id"))
         self.assertFalse(is_unique([{"id": 1}, {"id": 1}, {"id": 1}], attr="id"))
 
-    def test_validate_unique__works_with_classes(self):
+    def test_is_unique__works_with_classes(self):
         self.assertTrue(is_unique([Student(_id=1), Student(_id=2)], attr="id"))
         self.assertFalse(is_unique([Student(_id=1), Student(_id=1)], attr="id"))
+
+    def test_is_non_negative_integer(self):
+        self.assertTrue(is_non_negative_integer(0))
+        self.assertTrue(is_non_negative_integer(22222))
+        self.assertFalse(is_non_negative_integer(-1))
+        self.assertFalse(is_non_negative_integer(-222222))
+
+    def test_assert_can_exist_together__success(self):
+        projects = [
+            Project(_id=1),
+            Project(_id=2),
+        ]
+        assert_can_exist_together(
+            MockStudentProvider(MockStudentProviderSettings(number_of_students=10)),
+            None,
+        )
+        assert_can_exist_together(
+            MockStudentProvider(MockStudentProviderSettings(number_of_students=10)),
+            MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+        )
+        assert_can_exist_together(
+            MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1,2])),
+            MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+        )
+        assert_can_exist_together(
+            MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 2], num_project_preferences_per_student=2)),
+            MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+        )
+
+    def test_assert_can_exist_together__failure(self):
+        projects = [
+            Project(_id=1),
+            Project(_id=2),
+        ]
+        with self.assertRaises(ValueError):
+            assert_can_exist_together(
+                MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 3])),
+                MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+            )
+
+        with self.assertRaises(ValueError):
+            assert_can_exist_together(
+                MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 2], num_project_preferences_per_student=3)),
+                MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+            )
+
+        with self.assertRaises(ValueError):
+            assert_can_exist_together(
+                MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 2])),
+                None,
+            )

--- a/tests/test_utils/test_validation.py
+++ b/tests/test_utils/test_validation.py
@@ -2,8 +2,10 @@ import unittest
 
 from api.models.project import Project
 from api.models.student import Student
-from benchmarking.data.simulated_data.mock_initial_teams_provider import MockInitialTeamsProviderSettings, \
-    MockInitialTeamsProvider
+from benchmarking.data.simulated_data.mock_initial_teams_provider import (
+    MockInitialTeamsProviderSettings,
+    MockInitialTeamsProvider,
+)
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,
     MockStudentProviderSettings,
@@ -47,15 +49,31 @@ class TestValidationHelpers(unittest.TestCase):
         )
         assert_can_exist_together(
             MockStudentProvider(MockStudentProviderSettings(number_of_students=10)),
-            MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+            MockInitialTeamsProvider(
+                MockInitialTeamsProviderSettings(projects=projects)
+            ),
         )
         assert_can_exist_together(
-            MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1,2])),
-            MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+            MockStudentProvider(
+                MockStudentProviderSettings(
+                    number_of_students=10, project_preference_options=[1, 2]
+                )
+            ),
+            MockInitialTeamsProvider(
+                MockInitialTeamsProviderSettings(projects=projects)
+            ),
         )
         assert_can_exist_together(
-            MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 2], num_project_preferences_per_student=2)),
-            MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+            MockStudentProvider(
+                MockStudentProviderSettings(
+                    number_of_students=10,
+                    project_preference_options=[1, 2],
+                    num_project_preferences_per_student=2,
+                )
+            ),
+            MockInitialTeamsProvider(
+                MockInitialTeamsProviderSettings(projects=projects)
+            ),
         )
 
     def test_assert_can_exist_together__failure(self):
@@ -65,18 +83,36 @@ class TestValidationHelpers(unittest.TestCase):
         ]
         with self.assertRaises(ValueError):
             assert_can_exist_together(
-                MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 3])),
-                MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+                MockStudentProvider(
+                    MockStudentProviderSettings(
+                        number_of_students=10, project_preference_options=[1, 3]
+                    )
+                ),
+                MockInitialTeamsProvider(
+                    MockInitialTeamsProviderSettings(projects=projects)
+                ),
             )
 
         with self.assertRaises(ValueError):
             assert_can_exist_together(
-                MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 2], num_project_preferences_per_student=3)),
-                MockInitialTeamsProvider(MockInitialTeamsProviderSettings(projects=projects)),
+                MockStudentProvider(
+                    MockStudentProviderSettings(
+                        number_of_students=10,
+                        project_preference_options=[1, 2],
+                        num_project_preferences_per_student=3,
+                    )
+                ),
+                MockInitialTeamsProvider(
+                    MockInitialTeamsProviderSettings(projects=projects)
+                ),
             )
 
         with self.assertRaises(ValueError):
             assert_can_exist_together(
-                MockStudentProvider(MockStudentProviderSettings(number_of_students=10, project_preference_options=[1, 2])),
+                MockStudentProvider(
+                    MockStudentProviderSettings(
+                        number_of_students=10, project_preference_options=[1, 2]
+                    )
+                ),
                 None,
             )

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,19 +1,22 @@
-from typing import Any, List
+from typing import Any, List, TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from benchmarking.data.interfaces import StudentProvider, InitialTeamsProvider
 
 
-def is_unique(items: List[Any], attr: str = None):
+def is_unique(items: List[Any], attr: str = None) -> bool:
     """
     Checks if a list of anything contains unique elements (within the list).
     If attr is given, checks if they each have unique 'attr', where attr is an attribute of item's type.
 
     NOTE: Assumes that if attr is given, all dicts/objects in items have that 'attr' defined.
     """
-    if not attr:
-        return len(set(items)) == len(items)
-
     types_of_items = set([type(item) for item in items])
     if len(types_of_items) > 1:
         raise ValueError("All items should be of the same type.")
+
+    if not attr:
+        return len(set(items)) == len(items)
 
     # cast back to list to access by index
     if list(types_of_items)[0] == dict:
@@ -22,3 +25,58 @@ def is_unique(items: List[Any], attr: str = None):
         item_attrs = [getattr(item, attr) for item in items if getattr(item, attr)]
 
     return len(set(item_attrs)) == len(item_attrs)
+
+
+def assert_can_exist_together(
+    student_provider: "StudentProvider",
+    initial_teams_provider: Optional["InitialTeamsProvider"],
+):
+    from benchmarking.data.simulated_data.mock_initial_teams_provider import (
+        MockInitialTeamsProvider,
+    )
+    from benchmarking.data.simulated_data.mock_student_provider import (
+        MockStudentProvider,
+    )
+
+    if (student_provider and not isinstance(student_provider, MockStudentProvider)) or (
+        initial_teams_provider
+        and not isinstance(initial_teams_provider, MockInitialTeamsProvider)
+    ):
+        print(
+            "[WARNING]: No validation performed on harmony between student and initial teams providers when mock "
+            "providers are not being used. Proceed with caution."
+        )
+
+    if not student_provider.settings.project_preference_options:
+        return
+
+    if (
+        student_provider.settings.project_preference_options
+        and not initial_teams_provider
+    ):
+        raise ValueError(
+            "Cannot specify project_preference_options without providing projects to match them to."
+        )
+
+    if (
+        student_provider.settings.project_preference_options
+        and initial_teams_provider.settings.projects
+    ):
+        initial_teams_projects_set = set(
+            [p.id for p in initial_teams_provider.settings.projects]
+        )
+        if not set(student_provider.settings.project_preference_options).issubset(
+            initial_teams_projects_set
+        ):
+            raise ValueError(
+                "Mock student provider project preference options can only contain ids present in the projects passed "
+                "by the initial teams provider."
+            )
+
+
+def is_non_negative_integer(value: int) -> bool:
+    if not isinstance(value, int):
+        return False
+    if value < 0:
+        return False
+    return True


### PR DESCRIPTION
closes #125 

tldr; I got greedy and earlier thought I could represent project preferences as just any other attribute - we can't. It's important for many algorithms that we know what the project preferences are.

This PR conclusively makes `Student.project_preferences` *the* way to represent this info

Also included:
- MockStudentProvider can now mock students having preferences (it's more obvious how to do this, too, RE: #101 )
- Adding validations to mock student provider settings
- Adding compatibility validation between initial teams provider and student provider
- Minor improvements to validation utils