### PR TITLE
separate simulation from metric insights

### DIFF
--- a/benchmarking/runs/three_tokenization_constraints.py
+++ b/benchmarking/runs/three_tokenization_constraints.py
@@ -2,7 +2,7 @@ import math
 
 import typer
 
-from api.models.enums import ScenarioAttribute, Gender, Gpa, Age, Race
+from api.models.enums import ScenarioAttribute, Gpa, Age, Race
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProviderSettings,
     MockStudentProvider,
@@ -11,19 +11,15 @@ from benchmarking.evaluations.goals import DiversityGoal
 from benchmarking.evaluations.graphing.graph_metadata import GraphData
 from benchmarking.evaluations.graphing.line_graph import line_graph
 from benchmarking.evaluations.graphing.line_graph_metadata import LineGraphMetadata
-from benchmarking.evaluations.metrics.average_gini_index import AverageGiniIndex
 from benchmarking.evaluations.metrics.average_gini_index_multi_attribute import (
     AverageGiniIndexMultiAttribute,
 )
-from benchmarking.evaluations.metrics.maximum_gini_index import MaximumGiniIndex
-from benchmarking.evaluations.metrics.minimum_gini_index import MinimumGiniIndex
 from benchmarking.evaluations.metrics.priority_satisfaction import PrioritySatisfaction
 from benchmarking.evaluations.scenarios.three_tokenization_constraints import (
     ThreeTokenizationConstraints,
 )
-
-from benchmarking.simulation.goal_to_priority import goals_to_priorities
 from benchmarking.simulation.basic_simulation_set import BasicSimulationSet
+from benchmarking.simulation.goal_to_priority import goals_to_priorities
 
 
 def three_tokenization_constraints(

--- a/benchmarking/simulation/basic_simulation_set.py
+++ b/benchmarking/simulation/basic_simulation_set.py
@@ -17,13 +17,6 @@ from old.team_formation.app.team_generator.algorithm.algorithms import Algorithm
 
 RunOutput = Dict[AlgorithmType, Dict[str, List[float]]]
 
-DEFAULT_ALGORITHM_TYPES = [
-    AlgorithmType.RANDOM,
-    AlgorithmType.WEIGHT,
-    AlgorithmType.SOCIAL,
-    AlgorithmType.PRIORITY,
-]
-
 
 class BasicSimulationSet:
     """
@@ -31,6 +24,12 @@ class BasicSimulationSet:
     """
 
     KEY_RUNTIMES = "runtimes"
+    DEFAULT_ALGORITHM_TYPES = [
+        AlgorithmType.RANDOM,
+        AlgorithmType.WEIGHT,
+        AlgorithmType.SOCIAL,
+        AlgorithmType.PRIORITY,
+    ]
 
     def __init__(
         self,
@@ -47,7 +46,7 @@ class BasicSimulationSet:
 
         self.num_teams = num_teams
         self.initial_teams_provider = initial_teams_provider
-        self.algorithm_types = algorithm_types or DEFAULT_ALGORITHM_TYPES
+        self.algorithm_types = algorithm_types or self.DEFAULT_ALGORITHM_TYPES
 
         if not self.algorithm_types:
             raise ValueError(
@@ -58,7 +57,6 @@ class BasicSimulationSet:
         SimulationSettings(
             num_teams=num_teams,
             student_provider=student_provider,
-            metrics=metrics,
             initial_teams_provider=initial_teams_provider,
             scenario=scenario,
         )

--- a/benchmarking/simulation/basic_simulation_set_2.py
+++ b/benchmarking/simulation/basic_simulation_set_2.py
@@ -36,6 +36,8 @@ class BasicSimulationSet2:
 
     def run(self, num_runs: int) -> BasicSimulationSetArtifact:
         for algorithm_type in self.algorithm_types:
+            # todo: Simulation calculates team gen options and algo options internally, might be wise to not have
+            #  that be done N times, but not a huge performance bottleneck currently
             self.basic_simulation_set_artifact[algorithm_type] = Simulation(
                 algorithm_type=algorithm_type,
                 settings=self.base_settings,

--- a/benchmarking/simulation/basic_simulation_set_2.py
+++ b/benchmarking/simulation/basic_simulation_set_2.py
@@ -1,133 +1,51 @@
-import copy
-import statistics
-import time
-from collections import defaultdict
-from typing import List, Dict, Union
+from typing import List, Dict
 
-from api.ai.algorithm_runner import AlgorithmRunner
-from api.ai.new.interfaces.algorithm_options import AnyAlgorithmOptions
 from api.models.enums import AlgorithmType
-from benchmarking.data.interfaces import (
-    StudentProvider,
-    InitialTeamsProvider,
-)
-from benchmarking.evaluations.interfaces import Scenario, TeamSetMetric
-from benchmarking.simulation.mock_algorithm_2 import MockAlgorithm2
+from benchmarking.simulation.simulation import SimulationArtifact, Simulation
 from benchmarking.simulation.simulation_settings import SimulationSettings
 
-RunOutput = Dict[AlgorithmType, Dict[str, List[float]]]
-
-DEFAULT_ALGORITHM_TYPES = [
-    AlgorithmType.RANDOM,
-    AlgorithmType.WEIGHT,
-    AlgorithmType.SOCIAL,
-    AlgorithmType.PRIORITY,
-]
+BasicSimulationSetArtifact = Dict[AlgorithmType, SimulationArtifact]
 
 
 class BasicSimulationSet2:
     """
-    Represents running a Simulation num_runs times and returning the metrics from each of those runs.
+    Represents a set of Simulation runs for when we want to run only 1 of each algorithm
+        (as opposed to running 2+ instances of the same algorithm but with different configs)
     """
 
-    KEY_RUNTIMES = "runtimes"
+    DEFAULT_ALGORITHM_TYPES = [
+        AlgorithmType.RANDOM,
+        AlgorithmType.WEIGHT,
+        AlgorithmType.SOCIAL,
+        AlgorithmType.PRIORITY,
+    ]
 
     def __init__(
         self,
-        scenario: Scenario,
-        student_provider: StudentProvider,
-        metrics: List[TeamSetMetric],
-        num_teams: int = None,
-        initial_teams_provider: InitialTeamsProvider = None,
+        settings: SimulationSettings,
         algorithm_types: List[AlgorithmType] = None,
+        # todo: it's actually pretty easy to support a custom config for each of the algorithm types passed in
     ):
-        self.scenario = scenario
-        self.metrics = metrics
-        self.student_provider = student_provider
-
-        self.num_teams = num_teams
-        self.initial_teams_provider = initial_teams_provider
-        self.algorithm_types = algorithm_types or DEFAULT_ALGORITHM_TYPES
-
+        self.algorithm_types = algorithm_types or self.DEFAULT_ALGORITHM_TYPES
         if not self.algorithm_types:
             raise ValueError(
                 "If you override algorithm_types, you must specify at least 1 algorithm type to run a simulation."
             )
+        self.base_settings = settings
+        self.basic_simulation_set_artifact: BasicSimulationSetArtifact = {}
 
-        # fixme: temporary: creates this object so we get all the validations there for free
-        SimulationSettings(
-            num_teams=num_teams,
-            student_provider=student_provider,
-            metrics=metrics,
-            initial_teams_provider=initial_teams_provider,
-            scenario=scenario,
-        )
-
-        self.run_outputs = defaultdict(dict)
-        self.algorithm_options: Dict[
-            AlgorithmType, Union[None, AnyAlgorithmOptions]
-        ] = {}
+    def run(self, num_runs: int) -> BasicSimulationSetArtifact:
         for algorithm_type in self.algorithm_types:
-            self.run_outputs[algorithm_type] = {
-                metric.name: [] for metric in self.metrics
-            }
-            self.run_outputs[algorithm_type].update(
-                {BasicSimulationSet2.KEY_RUNTIMES: []}
-            )
-
-    def run(self, num_runs: int) -> RunOutput:
-        initial_teams = (
-            self.initial_teams_provider.get() if self.initial_teams_provider else None
-        )
-        team_generation_options = MockAlgorithm2.get_team_generation_options(
-            num_students=self.student_provider.num_students,
-            num_teams=self.num_teams,
-            initial_teams=initial_teams,
-        )
-
-        for _ in range(0, num_runs):
-            students = self.student_provider.get()
-
-            for algorithm_type in self.algorithm_types:
-                runner = AlgorithmRunner(
-                    algorithm_type=algorithm_type,
-                    team_generation_options=team_generation_options,
-                    algorithm_options=self._algorithm_options(algorithm_type),
-                )
-
-                start_time = time.time()
-                team_set = runner.generate(copy.deepcopy(students))
-                end_time = time.time()
-
-                self.run_outputs[algorithm_type][
-                    BasicSimulationSet2.KEY_RUNTIMES
-                ].append(end_time - start_time)
-                for metric in self.metrics:
-                    self.run_outputs[algorithm_type][metric.name].append(
-                        metric.calculate(team_set)
-                    )
-
-        return self.run_outputs
-
-    def _algorithm_options(self, algorithm_type: AlgorithmType):
-        if algorithm_type not in self.algorithm_options:
-            algorithm_options = MockAlgorithm2.algorithm_options_from_scenario(
+            self.basic_simulation_set_artifact[algorithm_type] = Simulation(
                 algorithm_type=algorithm_type,
-                scenario=self.scenario,
-                max_project_preferences=self.student_provider.max_project_preferences_per_student,
-            )
-            self.algorithm_options[algorithm_type] = algorithm_options
+                settings=self.base_settings,
+            ).run(num_runs)
 
-        return self.algorithm_options[algorithm_type]
+        return self.basic_simulation_set_artifact
 
     @staticmethod
-    def average_metric(
-        run_output: RunOutput, metric_name: str
-    ) -> Dict[AlgorithmType, float]:
-        averages_output = {}
-
-        for algorithm_type in run_output.keys():
-            metric_values = run_output[algorithm_type][metric_name]
-            averages_output[algorithm_type] = statistics.mean(metric_values)
-
-        return averages_output
+    def get_artifact(
+        basic_simulation_set_artifact: BasicSimulationSetArtifact,
+        algorithm_type: AlgorithmType,
+    ) -> SimulationArtifact:
+        return basic_simulation_set_artifact.get(algorithm_type, ([], []))

--- a/benchmarking/simulation/insight.py
+++ b/benchmarking/simulation/insight.py
@@ -1,0 +1,74 @@
+import statistics
+from typing import List, Dict
+
+from api.models.enums import AlgorithmType
+from api.models.team_set import TeamSet
+from benchmarking.evaluations.interfaces import TeamSetMetric
+from benchmarking.simulation.basic_simulation_set_2 import BasicSimulationSetArtifact
+from utils.validation import is_unique
+
+InsightOutput = Dict[str, List[float]]
+
+
+class Insight:
+    KEY_RUNTIMES = "runtimes"
+
+    def __init__(
+        self,
+        team_sets: List[TeamSet],
+        metrics: List[TeamSetMetric],
+        run_times: List[float] = None,
+    ):
+        self.team_sets = team_sets
+        self.metrics = metrics
+        self.run_times = run_times
+
+        if not self.team_sets:
+            raise ValueError("At least one team set must be specified for an insight.")
+        if not self.metrics:
+            raise ValueError("At least one metric must be specified for an insight.")
+        if self.run_times and len(self.run_times) != len(self.team_sets):
+            raise ValueError(
+                "If you provide run times, you must provide a run time for each team set provided."
+            )
+        if not is_unique([m.name for m in self.metrics]):
+            raise ValueError("The names of each metric specified must be unique.")
+
+        self.insight_output: InsightOutput = {
+            metric.name: [] for metric in self.metrics
+        }
+        self.insight_output.update({Insight.KEY_RUNTIMES: self.run_times})
+
+    def generate(self) -> InsightOutput:
+        for metric in self.metrics:
+            for team_set in self.team_sets:
+                self.insight_output[metric.name].append(metric.calculate(team_set))
+        return self.insight_output
+
+    @staticmethod
+    def average_metric(
+        insight_output_set: Dict[AlgorithmType, InsightOutput], metric_name: str
+    ) -> Dict[AlgorithmType, float]:
+        averages_output = {}
+
+        for algorithm_type in insight_output_set.keys():
+            metric_values = insight_output_set[algorithm_type][metric_name]
+            averages_output[algorithm_type] = statistics.mean(metric_values)
+
+        return averages_output
+
+    @staticmethod
+    def get_output_set(
+        artifact: BasicSimulationSetArtifact, metrics: List[TeamSetMetric]
+    ) -> Dict[AlgorithmType, InsightOutput]:
+        # designed to work with BasicSimulationSet, just a shortcut/utility
+        insight_output_set: Dict[AlgorithmType, InsightOutput] = {}
+
+        for algorithm_type in artifact.keys():
+            team_sets, run_times = artifact.get(algorithm_type, ([], []))
+            insight = Insight(
+                team_sets=team_sets, metrics=metrics, run_times=run_times
+            ).generate()
+            insight_output_set[algorithm_type] = insight
+
+        return insight_output_set

--- a/benchmarking/simulation/simulation_settings.py
+++ b/benchmarking/simulation/simulation_settings.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-from typing import List
 
 from benchmarking.data.interfaces import StudentProvider, InitialTeamsProvider
-from benchmarking.evaluations.interfaces import Scenario, TeamSetMetric
+from benchmarking.evaluations.interfaces import Scenario
 from utils.validation import assert_can_exist_together
 
 
@@ -10,8 +9,6 @@ from utils.validation import assert_can_exist_together
 class SimulationSettings:
     scenario: Scenario
     student_provider: StudentProvider
-    # todo: needed for now, will be removed when we separate metrics out
-    metrics: List[TeamSetMetric]
     num_teams: int = None
     initial_teams_provider: InitialTeamsProvider = None
 
@@ -27,7 +24,4 @@ class SimulationSettings:
             raise ValueError(
                 "Either num_teams OR a project initial_teams_provider must be specified."
             )
-        if not self.metrics:
-            raise ValueError("At least one metric must be specified for a simulation.")
-
         assert_can_exist_together(self.student_provider, self.initial_teams_provider)

--- a/old/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
+++ b/old/team_formation/app/team_generator/algorithm/priority_algorithm/priority_algorithm.py
@@ -19,9 +19,9 @@ class PriorityAlgorithm(WeightAlgorithm):
     """Class used to select teams using a priority algorithm."""
 
     MAX_KEEP: int = 3  # nodes
-    MAX_SPREAD: int = 3  # nodes
-    MAX_ITERATE: int = 15  # times
-    MAX_TIME: int = 30  # seconds
+    MAX_SPREAD: int = 1  # nodes
+    MAX_ITERATE: int = 1  # times
+    MAX_TIME: int = 1  # seconds
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_benchmarking/test_runs/test_run.py
+++ b/tests/test_benchmarking/test_runs/test_run.py
@@ -1,0 +1,59 @@
+import unittest
+
+from api.models.enums import AlgorithmType
+from api.models.project import Project
+from benchmarking.data.simulated_data.mock_initial_teams_provider import (
+    MockInitialTeamsProvider,
+    MockInitialTeamsProviderSettings,
+)
+from benchmarking.data.simulated_data.mock_student_provider import (
+    MockStudentProvider,
+    MockStudentProviderSettings,
+)
+from benchmarking.simulation.insight import Insight
+from benchmarking.simulation.simulation import Simulation
+from benchmarking.simulation.simulation_settings import SimulationSettings
+from tests.test_benchmarking.test_simulation._data import TestScenario, TestMetric
+
+
+class TestRun(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.scenario = TestScenario()
+        cls.student_provider = MockStudentProvider(
+            MockStudentProviderSettings(number_of_students=10),
+        )
+
+        cls.student_provider_with_preferences = MockStudentProvider(
+            MockStudentProviderSettings(
+                number_of_students=10,
+                project_preference_options=[1, 2],
+                num_project_preferences_per_student=2,
+            ),
+        )
+        cls.initial_teams_provider = MockInitialTeamsProvider(
+            MockInitialTeamsProviderSettings(
+                projects=[
+                    Project(_id=1),
+                    Project(_id=2),
+                ]
+            )
+        )
+        cls.complex_settings = SimulationSettings(
+            scenario=cls.scenario,
+            student_provider=cls.student_provider_with_preferences,
+            initial_teams_provider=cls.initial_teams_provider,
+        )
+        cls.metrics = [TestMetric(name="A"), TestMetric(name="B")]
+
+    def test_run__works_without_errors(self):
+        team_sets, run_times = Simulation(
+            algorithm_type=AlgorithmType.RANDOM,
+            settings=self.complex_settings,
+        ).run(num_runs=1)
+
+        Insight(
+            team_sets=team_sets,
+            run_times=run_times,
+            metrics=self.metrics,
+        ).generate()

--- a/tests/test_benchmarking/test_simulation/test_insight.py
+++ b/tests/test_benchmarking/test_simulation/test_insight.py
@@ -1,0 +1,74 @@
+import unittest
+from typing import List
+
+from api.models.enums import AlgorithmType
+from api.models.student import Student
+from api.models.team import Team
+from api.models.team_set import TeamSet
+from benchmarking.simulation.basic_simulation_set_2 import BasicSimulationSetArtifact
+from benchmarking.simulation.insight import Insight
+from tests.test_benchmarking.test_simulation._data import TestMetric
+
+
+class TestInsight(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.team_sets: List[TeamSet] = [
+            TeamSet(
+                _id=1,
+                teams=[
+                    Team(_id=1, students=[Student(_id=1)]),
+                    Team(_id=2, students=[Student(_id=2)]),
+                ],
+            ),
+            TeamSet(
+                _id=2,
+                teams=[
+                    Team(_id=3, students=[Student(_id=3)]),
+                    Team(_id=4, students=[Student(_id=4)]),
+                ],
+            ),
+        ]
+        cls.metrics = [TestMetric(name="A"), TestMetric(name="B")]
+
+    def test_generate__returns_correct_type_and_schema(self):
+        insight_output = Insight(
+            team_sets=self.team_sets,
+            metrics=self.metrics,
+            run_times=[1, 1],
+        ).generate()
+
+        self.assertEqual(len(insight_output.keys()), 3)
+        for key in insight_output.keys():
+            self.assertEqual(len(insight_output[key]), len(self.team_sets))
+        self.assertTrue(Insight.KEY_RUNTIMES in insight_output)
+
+        insight_output_2 = Insight(
+            team_sets=self.team_sets,
+            metrics=self.metrics,
+        ).generate()
+
+        self.assertEqual(len(insight_output_2.keys()), 3)
+        for key in insight_output_2.keys():
+            if key == Insight.KEY_RUNTIMES:
+                self.assertIsNone(insight_output_2[key])
+                continue
+            self.assertEqual(len(insight_output_2[key]), len(self.team_sets))
+
+    def test_average_metric__works_with_get_output_set(self):
+        mock_basic_simulation_set: BasicSimulationSetArtifact = {
+            AlgorithmType.RANDOM: (self.team_sets, [1, 1]),
+            AlgorithmType.WEIGHT: (self.team_sets, [1, 1]),
+        }
+
+        insight_output_set = Insight.get_output_set(
+            mock_basic_simulation_set, metrics=self.metrics
+        )
+        average_metric_insight = Insight.average_metric(
+            insight_output_set, metric_name="A"
+        )
+
+        self.assertEqual(len(average_metric_insight.keys()), 2)
+        for key in average_metric_insight.keys():
+            # can be an int if the numbers divide perfectly
+            self.assertIsInstance(average_metric_insight[key], (int, float))

--- a/tests/test_benchmarking/test_simulation/test_simulation.py
+++ b/tests/test_benchmarking/test_simulation/test_simulation.py
@@ -3,6 +3,7 @@ import unittest
 from api.ai.new.interfaces.algorithm_config import PriorityAlgorithmConfig
 from api.models.enums import AlgorithmType
 from api.models.project import Project
+from api.models.team_set import TeamSet
 from benchmarking.data.simulated_data.mock_initial_teams_provider import (
     MockInitialTeamsProvider,
     MockInitialTeamsProviderSettings,
@@ -11,7 +12,7 @@ from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,
     MockStudentProviderSettings,
 )
-from benchmarking.simulation.basic_simulation_set_2 import DEFAULT_ALGORITHM_TYPES
+from benchmarking.simulation.basic_simulation_set_2 import BasicSimulationSet2
 from benchmarking.simulation.simulation import Simulation
 from benchmarking.simulation.simulation_settings import SimulationSettings
 from tests.test_benchmarking.test_simulation._data import TestScenario, TestMetric
@@ -21,9 +22,6 @@ class TestSimulation(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.scenario = TestScenario()
-        cls.metric_1 = TestMetric(name="Test Metric 1")
-        cls.metric_2 = TestMetric(name="Test Metric 2")
-        cls.metric_3 = TestMetric(name="Test Metric 3")
         cls.student_provider = MockStudentProvider(
             MockStudentProviderSettings(number_of_students=10),
         )
@@ -31,11 +29,6 @@ class TestSimulation(unittest.TestCase):
             num_teams=2,
             scenario=cls.scenario,
             student_provider=cls.student_provider,
-            metrics=[
-                cls.metric_1,
-                cls.metric_2,
-                cls.metric_3,
-            ],
         )
 
         cls.student_provider_with_preferences = MockStudentProvider(
@@ -57,42 +50,33 @@ class TestSimulation(unittest.TestCase):
             scenario=cls.scenario,
             student_provider=cls.student_provider_with_preferences,
             initial_teams_provider=cls.initial_teams_provider,
-            metrics=[
-                cls.metric_1,
-                cls.metric_2,
-                cls.metric_3,
-            ],
         )
 
-    def test_run__outputs_match_given_metrics_and_trials(self):
-        simulation_output = Simulation(
+    def test_run__outputs_match_given_trials_and_schema(self):
+        team_sets, run_times = Simulation(
             algorithm_type=AlgorithmType.RANDOM,
             settings=self.settings,
         ).run(num_runs=5)
 
-        self.assertEqual(
-            len(simulation_output.keys()),
-            4,
-            msg="Simulation output for {} doesn't include the correct number of keys (3 metrics + 1 runtime)",
-        )
-        for name in ["Test Metric 1", "Test Metric 2", "Test Metric 3"]:
-            self.assertTrue(name in simulation_output)
-            self.assertEqual(
-                len(simulation_output[name]),
-                5,
-                msg="Incorrect number of trials for metric.",
-            )
-        self.assertTrue(Simulation.KEY_RUNTIMES in simulation_output)
+        self.assertEqual(len(team_sets), 5)
+        self.assertEqual(len(run_times), 5)
+        # redundant but left in as a safeguard for future logic changes
+        self.assertEqual(len(team_sets), len(run_times))
+
+        for team_set in team_sets:
+            self.assertIsInstance(team_set, TeamSet)
+        for run_time in run_times:
+            self.assertIsInstance(run_time, float)
 
     def test_run__works_with_each_algorithm_type(self):
-        for algorithm_type in DEFAULT_ALGORITHM_TYPES:
+        for algorithm_type in BasicSimulationSet2.DEFAULT_ALGORITHM_TYPES:
             Simulation(
                 algorithm_type=algorithm_type,
                 settings=self.settings,
             ).run(num_runs=1)
 
     def test_run__works_with_complex_settings(self):
-        for algorithm_type in DEFAULT_ALGORITHM_TYPES:
+        for algorithm_type in BasicSimulationSet2.DEFAULT_ALGORITHM_TYPES:
             Simulation(
                 algorithm_type=algorithm_type,
                 settings=self.complex_settings,


### PR DESCRIPTION
closes #111 
closes #167 

- establishes an `Insight` class for processing the outputs of simulations through the lens of metrics
- kinda just decided simulations will return a tuple so run time information is not lost
- BasicSimulationSet2 (the one not being used yet) now explicitly just runs a loop of `Simulation` (I'm just ignoring the performance of this, but left a comment)
- fixed tests as needed
- small quality of life changes
