### PR TITLE
enforce unique ids on intial teams specifications

### DIFF
--- a/api/ai/new/interfaces/algorithm.py
+++ b/api/ai/new/interfaces/algorithm.py
@@ -63,15 +63,18 @@ class Algorithm(ABC):
                 ]
             )
 
+        largest_existing_id = max([t.id for t in initial_teams]) if initial_teams else 0
+        team_names = [t.name for t in initial_teams]
+
         # Create the remaining teams with unique names
-        counter = 1
+        new_team_id = largest_existing_id + 1
         while len(initial_teams) < team_generation_options.total_teams:
-            name = f"Team {counter}"
-            # todo: do this better, it loops through all names every time
-            if name not in map(lambda t: t.name, initial_teams):
-                # todo: unique id must be ensured now
-                initial_teams.append(Team(_id=-1, name=name))
-            counter += 1
+            name = f"Team {new_team_id}"
+            if name not in team_names:
+                new_team = Team(_id=new_team_id, name=name)
+                initial_teams.append(new_team)
+                team_names.append(new_team.name)
+            new_team_id += 1
 
         return initial_teams
 

--- a/api/ai/new/interfaces/algorithm.py
+++ b/api/ai/new/interfaces/algorithm.py
@@ -64,7 +64,7 @@ class Algorithm(ABC):
             )
 
         largest_existing_id = max([t.id for t in initial_teams]) if initial_teams else 0
-        team_names = [t.name for t in initial_teams]
+        team_names = set([t.name for t in initial_teams])
 
         # Create the remaining teams with unique names
         new_team_id = largest_existing_id + 1
@@ -73,7 +73,7 @@ class Algorithm(ABC):
             if name not in team_names:
                 new_team = Team(_id=new_team_id, name=name)
                 initial_teams.append(new_team)
-                team_names.append(new_team.name)
+                team_names.add(new_team.name)
             new_team_id += 1
 
         return initial_teams

--- a/api/ai/new/interfaces/team_generation_options.py
+++ b/api/ai/new/interfaces/team_generation_options.py
@@ -4,6 +4,7 @@ from typing import List
 from schema import Schema
 
 from api.models.team import TeamShell
+from utils.validation import is_unique
 
 
 @dataclass
@@ -11,7 +12,6 @@ class TeamGenerationOptions:
     max_team_size: int
     min_team_size: int
     total_teams: int
-    # todo: add support for initial team options in new Algorithm structure
     initial_teams: List[TeamShell]
 
     def __post_init__(self):
@@ -27,7 +27,9 @@ class TeamGenerationOptions:
             )
         if self.initial_teams:
             Schema([TeamShell]).validate(self.initial_teams)
-            if len(self.initial_teams) != self.total_teams:
+            if not is_unique([t.id for t in self.initial_teams]):
+                raise ValueError(f"Ids of team shells must be unique!")
+            if len(self.initial_teams) > self.total_teams:
                 raise ValueError(
-                    f"team_options size ({len(self.initial_teams)}) != total_teams ({self.total_teams})"
+                    f"team_options size ({len(self.initial_teams)}) > total_teams ({self.total_teams})"
                 )

--- a/api/models/team/model.py
+++ b/api/models/team/model.py
@@ -34,9 +34,10 @@ class Team(TeamShell):
 
     @classmethod
     def from_shell(cls, shell: TeamShell) -> "Team":
+        name = shell.name or f"Team {shell.id}"
         return cls(
             _id=shell.id,
-            name=shell.name,
+            name=name,
             project_id=shell.project_id,
             requirements=shell.requirements,
             is_locked=shell.is_locked,

--- a/tests/test_api/test_ai/test_interfaces/test_algorithm.py
+++ b/tests/test_api/test_ai/test_interfaces/test_algorithm.py
@@ -1,0 +1,53 @@
+import unittest
+
+from api.ai.new.interfaces.algorithm import Algorithm
+from api.ai.new.interfaces.team_generation_options import TeamGenerationOptions
+from api.models.team import TeamShell
+from utils.validation import is_unique
+
+
+class TestAlgorithm(unittest.TestCase):
+    def test_create_initial_teams__creates_teams_with_unique_ideas(self):
+        # without initial teams
+        team_generation_options_1 = TeamGenerationOptions(
+            max_team_size=5, min_team_size=4, total_teams=4, initial_teams=[]
+        )
+        teams_1 = Algorithm.create_initial_teams(team_generation_options_1)
+        self.assertTrue(is_unique([t.id for t in teams_1]))
+        self.assertTrue(is_unique([t.name for t in teams_1]))
+
+        # with initial teams
+        team_generation_options_2 = TeamGenerationOptions(
+            max_team_size=5,
+            min_team_size=4,
+            total_teams=4,
+            initial_teams=[
+                TeamShell(_id=2),
+                TeamShell(_id=20),
+            ],
+        )
+        teams_2 = Algorithm.create_initial_teams(team_generation_options_2)
+        teams_2_ids = [t.id for t in teams_2]
+        self.assertTrue(is_unique(teams_2_ids))
+        self.assertTrue(is_unique([t.name for t in teams_2]))
+        # the 2 new teams created to reach total_teams should have these 2 ids specifically
+        self.assertTrue(21 in teams_2_ids)
+        self.assertTrue(22 in teams_2_ids)
+
+        # with initial teams with names that will clash
+        team_generation_options_3 = TeamGenerationOptions(
+            max_team_size=5,
+            min_team_size=4,
+            total_teams=4,
+            initial_teams=[
+                TeamShell(_id=2, name="Team 21"),
+                TeamShell(_id=20, name="Team 22"),
+            ],
+        )
+        teams_3 = Algorithm.create_initial_teams(team_generation_options_3)
+        teams_3_ids = [t.id for t in teams_3]
+        self.assertTrue(is_unique(teams_3_ids))
+        self.assertTrue(is_unique([t.name for t in teams_3]))
+        # the 2 new teams created to reach total_teams should have these 2 ids specifically
+        self.assertTrue(23 in teams_3_ids)
+        self.assertTrue(24 in teams_3_ids)


### PR DESCRIPTION
closes #168 

- Enforces that TeamShells specified in the initial_teams of team gen options must be unique.
    - Medium value, but sometimes matters for logic that each team has a unique id (and generally is important)
    - It is predicted to be relevant for API responses that these ids are unique, too
- More strictly enforces name uniqueness too
- Fixed some validation in team gen options (it is okay to give less initial_teams than total_teams, the logic will fill in the teams you don't specify explicitly until we have total_teams)