### PR TITLE
add cache keys to basic simulation set

### DIFF
--- a/benchmarking/simulation/basic_simulation_set_2.py
+++ b/benchmarking/simulation/basic_simulation_set_2.py
@@ -32,6 +32,7 @@ class BasicSimulationSet2:
                 "If you override algorithm_types, you must specify at least 1 algorithm type to run a simulation."
             )
         self.base_settings = settings
+        self.base_cache_key = self.base_settings.cache_key
         self.basic_simulation_set_artifact: BasicSimulationSetArtifact = {}
 
     def run(self, num_runs: int) -> BasicSimulationSetArtifact:
@@ -40,10 +41,26 @@ class BasicSimulationSet2:
             #  that be done N times, but not a huge performance bottleneck currently
             self.basic_simulation_set_artifact[algorithm_type] = Simulation(
                 algorithm_type=algorithm_type,
-                settings=self.base_settings,
+                settings=self.get_simulation_settings_from_base(algorithm_type),
             ).run(num_runs)
 
         return self.basic_simulation_set_artifact
+
+    def get_simulation_settings_from_base(
+        self, algorithm_type: AlgorithmType
+    ) -> SimulationSettings:
+        cache_key = (
+            f"{self.base_settings.cache_key}/{str(algorithm_type)}"
+            if self.base_settings.cache_key
+            else None
+        )
+        return SimulationSettings(
+            scenario=self.base_settings.scenario,
+            student_provider=self.base_settings.student_provider,
+            initial_teams_provider=self.base_settings.initial_teams_provider,
+            num_teams=self.base_settings.num_teams,
+            cache_key=cache_key,
+        )
 
     @staticmethod
     def get_artifact(

--- a/tests/test_benchmarking/test_simulation/test_basic_simulation_set_2.py
+++ b/tests/test_benchmarking/test_simulation/test_basic_simulation_set_2.py
@@ -1,0 +1,62 @@
+import unittest
+
+from api.models.enums import AlgorithmType
+from benchmarking.data.simulated_data.mock_student_provider import (
+    MockStudentProvider,
+    MockStudentProviderSettings,
+)
+from benchmarking.simulation.basic_simulation_set_2 import BasicSimulationSet2
+from benchmarking.simulation.simulation_settings import SimulationSettings
+from tests.test_benchmarking.test_simulation._data import TestScenario
+from utils.validation import is_unique
+
+
+class TestBasicSimulationSet(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.scenario = TestScenario()
+        cls.student_provider = MockStudentProvider(
+            MockStudentProviderSettings(number_of_students=10),
+        )
+
+    def test_get_simulation_settings_from_base__preserves_all_other_settings(self):
+        # ensures that if more fields are added to the settings class,
+        #   then they are updated in this method to ensure preservation
+        base_settings = SimulationSettings(
+            num_teams=2,
+            scenario=self.scenario,
+            student_provider=self.student_provider,
+            cache_key="test_cache_key",
+        )
+        simulation_set = BasicSimulationSet2(
+            settings=base_settings,
+        )
+
+        modified_settings = simulation_set.get_simulation_settings_from_base(
+            AlgorithmType.RANDOM
+        )
+        self.assertIsNotNone(base_settings.cache_key)
+        for field_name in SimulationSettings.__dataclass_fields__.keys():
+            if field_name == "cache_key":  # cache key should be different
+                continue
+            self.assertEqual(
+                modified_settings.__getattribute__(field_name),
+                base_settings.__getattribute__(field_name),
+            )
+
+    def test_get_simulation_settings_from_base__creates_unique_cache_keys(self):
+        simulation_set = BasicSimulationSet2(
+            settings=SimulationSettings(
+                num_teams=2,
+                scenario=self.scenario,
+                student_provider=self.student_provider,
+                cache_key="test_cache_key",
+            ),
+        )
+
+        generated_keys = [
+            simulation_set.get_simulation_settings_from_base(t).cache_key
+            for t in AlgorithmType
+        ]
+        self.assertGreater(len(generated_keys), 0)
+        self.assertTrue(is_unique(generated_keys))


### PR DESCRIPTION
closes #174 

- Automatically creates a nested cache folder for each algorithm type it runs for within the base cache key