### PR TITLE
add mutation config

### DIFF
--- a/api/ai/new/priority_algorithm/mutations/__init__.py
+++ b/api/ai/new/priority_algorithm/mutations/__init__.py
@@ -1,0 +1,3 @@
+from .random_swap import mutate_random_swap
+from .local_max import mutate_local_max
+from .robinhood import mutate_robinhood, mutate_robinhood_holistic

--- a/api/ai/new/priority_algorithm/mutations/random_swap.py
+++ b/api/ai/new/priority_algorithm/mutations/random_swap.py
@@ -16,7 +16,9 @@ def swap_student_between_teams(
     team_2.student_ids.append(student_1_id)
 
 
-def mutate_random_swap(priority_team_set: PriorityTeamSet) -> PriorityTeamSet:
+def mutate_random_swap(
+    priority_team_set: PriorityTeamSet, *args, **kwargs
+) -> PriorityTeamSet:
     available_priority_teams = [
         priority_team
         for priority_team in priority_team_set.priority_teams

--- a/tests/test_api/test_ai/test_algorithm_runner.py
+++ b/tests/test_api/test_ai/test_algorithm_runner.py
@@ -8,3 +8,11 @@ class TestAlgorithmRunner(unittest.TestCase):
     def test_get_algorithm_from_type__all_algorithm_types_must_have_classes(self):
         for algorithm_type in AlgorithmType:
             AlgorithmRunner.get_algorithm_from_type(algorithm_type)
+
+    def test_get_algorithm_options_class__all_algorithm_types_must_have_classes(self):
+        for algorithm_type in AlgorithmType:
+            AlgorithmRunner.get_algorithm_option_class(algorithm_type)
+
+    def test_get_algorithm_config_class__all_algorithm_types_must_have_classes(self):
+        for algorithm_type in AlgorithmType:
+            AlgorithmRunner.get_algorithm_config_class(algorithm_type)

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+from api.ai.new.interfaces.algorithm_config import PriorityAlgorithmConfig
+from api.ai.new.interfaces.algorithm_options import PriorityAlgorithmOptions
+from api.ai.new.interfaces.team_generation_options import TeamGenerationOptions
+from api.ai.new.priority_algorithm.custom_models import PriorityTeamSet
+import api.ai.new.priority_algorithm.mutations  # done this way to mutation functions can be mocked properly
+from api.ai.new.priority_algorithm.priority_algorithm import PriorityAlgorithm
+from benchmarking.data.simulated_data.mock_student_provider import (
+    MockStudentProvider,
+    MockStudentProviderSettings,
+)
+
+
+def do_nothing_mutation(
+    priority_team_set: PriorityTeamSet, *args, **kwargs
+) -> PriorityTeamSet:
+    return priority_team_set
+
+
+def do_nothing_mutation_2(
+    priority_team_set: PriorityTeamSet, *args, **kwargs
+) -> PriorityTeamSet:
+    return priority_team_set
+
+
+class TestPriorityAlgorithm(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.algorithm_options = PriorityAlgorithmOptions(
+            priorities=[],
+            max_project_preferences=0,
+        )
+        cls.team_generation_options = TeamGenerationOptions(
+            max_team_size=5,
+            min_team_size=4,
+            total_teams=2,
+            initial_teams=[],
+        )
+
+    @mock.patch(
+        "api.ai.new.priority_algorithm.mutations.mutate_random_swap", return_value=[]
+    )
+    @mock.patch(
+        "api.ai.new.priority_algorithm.mutations.mutate_local_max", return_value=[]
+    )
+    def test_mutate__uses_mutation_functions_from_config(
+        self, mock_local_max, mock_random_swap
+    ):
+        algorithm_config = PriorityAlgorithmConfig(
+            MAX_SPREAD=10,
+            MAX_TIME=100,
+            MAX_ITERATE=1,
+            MAX_KEEP=3,
+            MUTATIONS=[
+                (api.ai.new.priority_algorithm.mutations.mutate_random_swap, 7),
+                (api.ai.new.priority_algorithm.mutations.mutate_local_max, 3),
+            ],
+        )
+        algorithm = PriorityAlgorithm(
+            algorithm_options=self.algorithm_options,
+            team_generation_options=self.team_generation_options,
+            algorithm_config=algorithm_config,
+        )
+
+        test_team_set = algorithm.generate_initial_team_set(
+            MockStudentProvider(
+                settings=MockStudentProviderSettings(
+                    number_of_students=10,
+                )
+            ).get()
+        )
+
+        algorithm.mutate(test_team_set)
+        self.assertEqual(mock_random_swap.call_count, 7)
+        self.assertEqual(mock_local_max.call_count, 3)
+
+    def test_mutate__returns_correct_number_of_mutated_team_sets(self):
+        algorithm_config = PriorityAlgorithmConfig(
+            MAX_SPREAD=10,
+            MAX_TIME=100,
+            MAX_ITERATE=1,
+            MAX_KEEP=3,
+        )
+        algorithm = PriorityAlgorithm(
+            algorithm_options=self.algorithm_options,
+            team_generation_options=self.team_generation_options,
+            algorithm_config=algorithm_config,
+        )
+
+        test_team_set = algorithm.generate_initial_team_set(
+            MockStudentProvider(
+                settings=MockStudentProviderSettings(
+                    number_of_students=10,
+                )
+            ).get()
+        )
+
+        mutated_team_sets = algorithm.mutate(test_team_set)
+        self.assertEqual(len(mutated_team_sets), algorithm_config.MAX_SPREAD)

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
@@ -5,7 +5,6 @@ import api.ai.new.priority_algorithm.mutations  # done this way to mutation func
 from api.ai.new.interfaces.algorithm_config import PriorityAlgorithmConfig
 from api.ai.new.interfaces.algorithm_options import PriorityAlgorithmOptions
 from api.ai.new.interfaces.team_generation_options import TeamGenerationOptions
-from api.ai.new.priority_algorithm.custom_models import PriorityTeamSet
 from api.ai.new.priority_algorithm.priority_algorithm import PriorityAlgorithm
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
@@ -1,12 +1,11 @@
 import unittest
 from unittest import mock
-from unittest.mock import patch
 
+import api.ai.new.priority_algorithm.mutations  # done this way to mutation functions can be mocked properly
 from api.ai.new.interfaces.algorithm_config import PriorityAlgorithmConfig
 from api.ai.new.interfaces.algorithm_options import PriorityAlgorithmOptions
 from api.ai.new.interfaces.team_generation_options import TeamGenerationOptions
 from api.ai.new.priority_algorithm.custom_models import PriorityTeamSet
-import api.ai.new.priority_algorithm.mutations  # done this way to mutation functions can be mocked properly
 from api.ai.new.priority_algorithm.priority_algorithm import PriorityAlgorithm
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority_algorithm.py
@@ -13,18 +13,6 @@ from benchmarking.data.simulated_data.mock_student_provider import (
 )
 
 
-def do_nothing_mutation(
-    priority_team_set: PriorityTeamSet, *args, **kwargs
-) -> PriorityTeamSet:
-    return priority_team_set
-
-
-def do_nothing_mutation_2(
-    priority_team_set: PriorityTeamSet, *args, **kwargs
-) -> PriorityTeamSet:
-    return priority_team_set
-
-
 class TestPriorityAlgorithm(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
closes #102 

- adds a mutations config to the priority algorithm config
    - specifies mutation functions and how many team sets should be mutated this way
    - must sync with MAX_SPREAD
    - used in the algorithm and tested
    - implemented a default for this

NOTE: this kinda means all mutation functions in the future kinda sorta need to take the same params (ish, see what happened to random swap for lore)

Bonus: learned about mocking today :D