### PR TITLE
Added option to save graphs

### DIFF
--- a/benchmarking/evaluations/graphing/line_graph.py
+++ b/benchmarking/evaluations/graphing/line_graph.py
@@ -107,4 +107,7 @@ def line_graph(graph_data: LineGraphMetadata):
     make_space_above(ax)
 
     plt.tight_layout()
-    plt.show()
+    if graph_data.save_graph:
+        plt.savefig(graph_data.file_name or graph_data.title)
+    else:
+        plt.show()

--- a/benchmarking/evaluations/graphing/line_graph_metadata.py
+++ b/benchmarking/evaluations/graphing/line_graph_metadata.py
@@ -10,7 +10,9 @@ class LineGraphMetadata:
     data: List[GraphData]
     x_label: str
     y_label: str
-    description: Optional[str]
-    x_lim: Optional[GraphAxisRange]
-    y_lim: Optional[GraphAxisRange]
-    num_minor_ticks: Optional[int]
+    description: Optional[str] = None
+    x_lim: Optional[GraphAxisRange] = None
+    y_lim: Optional[GraphAxisRange] = None
+    num_minor_ticks: Optional[int] = None
+    save_graph: bool = False
+    file_name: Optional[str] = None


### PR DESCRIPTION
### Changes
- Can use `save_graph` attribute of `LineGraphMetadata` to save a graph
- Can use `file_name` attribute of `LineGraphMetadata` to specify the filename for the saved graph, defaults to the graph title
- Also made the `Optional` attributes of `LineGraphMetadata` actually optional by defaulting them to None

Closes #188 