### PR TITLE
implement diversity priority without tokenization [204]

### DIFF
--- a/api/ai/new/priority_algorithm/mutations/robinhood.py
+++ b/api/ai/new/priority_algorithm/mutations/robinhood.py
@@ -8,6 +8,8 @@ from api.ai.new.priority_algorithm.custom_models import PriorityTeamSet, Priorit
 from api.models.student import Student
 
 
+ROBINHOOD_SATISFACTION_THRESHOLD = 0.8
+
 def mutate_robinhood(
     priority_team_set: PriorityTeamSet,
     priorities: List[Priority],
@@ -41,9 +43,9 @@ def mutate_robinhood(
             satisfied_teams: List[PriorityTeam] = []
             unsatisfied_teams: List[PriorityTeam] = []
             for team in available_priority_teams:
-                if priority.satisfied_by(
+                if priority.satisfaction(
                     [student_dict[student_id] for student_id in team.student_ids]
-                ):
+                ) >= ROBINHOOD_SATISFACTION_THRESHOLD:
                     satisfied_teams.append(team)
                 else:
                     unsatisfied_teams.append(team)

--- a/api/ai/new/priority_algorithm/mutations/robinhood.py
+++ b/api/ai/new/priority_algorithm/mutations/robinhood.py
@@ -10,6 +10,7 @@ from api.models.student import Student
 
 ROBINHOOD_SATISFACTION_THRESHOLD = 0.8
 
+
 def mutate_robinhood(
     priority_team_set: PriorityTeamSet,
     priorities: List[Priority],
@@ -43,9 +44,12 @@ def mutate_robinhood(
             satisfied_teams: List[PriorityTeam] = []
             unsatisfied_teams: List[PriorityTeam] = []
             for team in available_priority_teams:
-                if priority.satisfaction(
-                    [student_dict[student_id] for student_id in team.student_ids]
-                ) >= ROBINHOOD_SATISFACTION_THRESHOLD:
+                if (
+                    priority.satisfaction(
+                        [student_dict[student_id] for student_id in team.student_ids]
+                    )
+                    >= ROBINHOOD_SATISFACTION_THRESHOLD
+                ):
                     satisfied_teams.append(team)
                 else:
                     unsatisfied_teams.append(team)

--- a/api/ai/new/priority_algorithm/priority/interfaces.py
+++ b/api/ai/new/priority_algorithm/priority/interfaces.py
@@ -1,14 +1,20 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import List
 
 from api.models.student import Student
 
 
+@dataclass
 class Priority(ABC):
+    def __post_init__(self):
+        self.validate()
+
     @abstractmethod
     def validate(self):
         pass
 
     @abstractmethod
-    def satisfied_by(self, students: List[Student]) -> bool:
+    def satisfaction(self, students: List[Student]) -> float:
+        # should always return a value in the range [0, 1]
         raise NotImplementedError

--- a/api/ai/new/priority_algorithm/priority/priority.py
+++ b/api/ai/new/priority_algorithm/priority/priority.py
@@ -66,4 +66,6 @@ class DiversityPriority(Priority):
 
     def satisfaction(self, students: List[Student]) -> float:
         blau_index = _blau_index(students, self.attribute_id)
-        return blau_index if self.strategy == DiversifyType.DIVERSIFY else (1 - blau_index)
+        return (
+            blau_index if self.strategy == DiversifyType.DIVERSIFY else (1 - blau_index)
+        )

--- a/api/ai/new/priority_algorithm/scoring.py
+++ b/api/ai/new/priority_algorithm/scoring.py
@@ -43,7 +43,7 @@ def get_satisfaction_ratio(
     # returns value in [0, 1] IMPORTANT that it does this, satisfaction value relies on it
     count = 0
     for priority_team in priority_teams:
-        count += priority.satisfied_by(
+        count += priority.satisfaction(
             [student_dict[student_id] for student_id in priority_team.student_ids]
         )
     return count / len(priority_teams)

--- a/api/ai/priority_algorithm/priority.py
+++ b/api/ai/priority_algorithm/priority.py
@@ -12,7 +12,7 @@ class TokenizationPriority(Priority):
     strategy: DiversifyType
     direction: TokenizationConstraintDirection
     threshold: int  # number representing k
-    value: str  # string representing x
+    value: int  # string representing x
 
     def __post_init__(self, *args, **kwargs):
         self.validate()

--- a/benchmarking/evaluations/metrics/priority_satisfaction.py
+++ b/benchmarking/evaluations/metrics/priority_satisfaction.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from api.ai.priority_algorithm.interfaces import Priority
+from api.ai.new.priority_algorithm.priority.interfaces import Priority
 from api.models.team import Team
 from api.models.team_set import TeamSet
 from benchmarking.evaluations.interfaces import TeamSetMetric
@@ -45,8 +45,8 @@ class PrioritySatisfaction(TeamSetMetric):
         weights = [(2 ** (k - i)) / ((2**k) - 1) for i in range(1, k + 1)]
         return weights
 
-    def priorities_satisfied(self, team: Team) -> List[int]:
+    def priorities_satisfied(self, team: Team) -> List[float]:
         satisfied = [
-            int(priority.satisfied_by(team.students)) for priority in self.priorities
+            priority.satisfaction(team.students) for priority in self.priorities
         ]
         return satisfied

--- a/benchmarking/simulation/goal_to_priority.py
+++ b/benchmarking/simulation/goal_to_priority.py
@@ -1,7 +1,7 @@
-from typing import List, Literal
+from typing import List
 
-from api.ai.priority_algorithm.interfaces import Priority
-from api.ai.priority_algorithm.priority import TokenizationPriority
+from api.ai.new.priority_algorithm.priority.interfaces import Priority
+from api.ai.new.priority_algorithm.priority.priority import DiversityPriority, TokenizationPriority
 from benchmarking.evaluations.goals import DiversityGoal
 from benchmarking.evaluations.interfaces import Goal
 
@@ -13,8 +13,12 @@ def goals_to_priorities(goals: List[Goal]) -> List[Priority]:
 def goal_to_priority(goal: Goal) -> Priority:
     if not isinstance(goal, DiversityGoal):
         raise NotImplementedError
+
     if goal.tokenization_constraint is None:
-        raise NotImplementedError
+        return DiversityPriority(
+            attribute_id=goal.attribute,
+            strategy=goal.strategy,
+        )
 
     return TokenizationPriority(
         attribute_id=goal.attribute,

--- a/benchmarking/simulation/goal_to_priority.py
+++ b/benchmarking/simulation/goal_to_priority.py
@@ -1,7 +1,10 @@
 from typing import List
 
 from api.ai.new.priority_algorithm.priority.interfaces import Priority
-from api.ai.new.priority_algorithm.priority.priority import DiversityPriority, TokenizationPriority
+from api.ai.new.priority_algorithm.priority.priority import (
+    DiversityPriority,
+    TokenizationPriority,
+)
 from benchmarking.evaluations.goals import DiversityGoal
 from benchmarking.evaluations.interfaces import Goal
 

--- a/tests/test_api/test_ai/test_priority_algorithm/test_mutations/test_local_max.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_mutations/test_local_max.py
@@ -18,11 +18,11 @@ class EvenPriority(Priority):
     A mock priority to check that all students in a team have an even student id
     """
 
-    def satisfied_by(self, students: List[Student]) -> bool:
+    def satisfaction(self, students: List[Student]) -> float:
         for student in students:
             if student.id % 2 == 1:
-                return False
-        return True
+                return 0
+        return 1
 
     def validate(self) -> bool:
         return True
@@ -34,11 +34,11 @@ class JohnPriority(Priority):
     A mock priority that checks if a team has a student named John
     """
 
-    def satisfied_by(self, students: List[Student]) -> bool:
+    def satisfaction(self, students: List[Student]) -> float:
         for student in students:
             if student.name == "John":
-                return True
-        return False
+                return 1
+        return 0
 
     def validate(self) -> bool:
         return True

--- a/tests/test_api/test_ai/test_priority_algorithm/test_mutations/test_util.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_mutations/test_util.py
@@ -1,9 +1,9 @@
 import unittest
 from typing import List
 
-from api.ai.priority_algorithm.interfaces import Priority
-from api.ai.priority_algorithm.mutations.utils import score
-from api.ai.priority_algorithm.priority_teamset import PriorityTeamSet, PriorityTeam
+from api.ai.new.priority_algorithm.priority.interfaces import Priority
+from api.ai.new.priority_algorithm.mutations.utils import score
+from api.ai.new.priority_algorithm.custom_models import PriorityTeamSet, PriorityTeam
 from api.models.student import Student
 from api.models.team import Team
 from tests.test_api.test_ai.test_priority_algorithm.test_mutations.test_local_max import (

--- a/tests/test_benchmarking/test_simulation/test_goal_to_priority.py
+++ b/tests/test_benchmarking/test_simulation/test_goal_to_priority.py
@@ -1,7 +1,10 @@
 import unittest
 from typing import List
 
-from api.ai.new.priority_algorithm.priority.priority import TokenizationPriority, DiversityPriority
+from api.ai.new.priority_algorithm.priority.priority import (
+    TokenizationPriority,
+    DiversityPriority,
+)
 from api.models.enums import (
     DiversifyType,
     ScenarioAttribute,


### PR DESCRIPTION
closes #204 

- Adds regular diversification/concentration priorities
    - implemented into the algorithm runner so it'll auto convert
- The thing to note here is that Priority subclasses will now have a `def satisfaction() -> float` instead of a `def satisfied_by() -> bool`. This is because the logic actually works essentially the same with minor modifications and then allows the question "does this group of students satisfy this priority" to be more like "how much does this team of students satisfy this priority"