### PR TITLE
improve tokenization priority

### DIFF
--- a/api/ai/priority_algorithm/priority/priority.py
+++ b/api/ai/priority_algorithm/priority/priority.py
@@ -38,11 +38,15 @@ class TokenizationPriority(Priority):
 
     def satisfaction(self, students: List[Student], team_shell: TeamShell) -> float:
         blau_index = _blau_index(students, self.attribute_id)
-        general_diversity = blau_index if self.strategy == DiversifyType.DIVERSIFY else (1 - blau_index)
+        general_diversity = (
+            blau_index if self.strategy == DiversifyType.DIVERSIFY else (1 - blau_index)
+        )
 
         tokenized_student_count = 0
         for student in students:
-            tokenized_student_count += self.value in student.attributes.get(self.attribute_id, [])
+            tokenized_student_count += self.value in student.attributes.get(
+                self.attribute_id, []
+            )
         meets_threshold = self.student_count_meets_threshold(tokenized_student_count)
 
         if not meets_threshold:

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority/test_priority.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority/test_priority.py
@@ -3,11 +3,126 @@ import unittest
 from api.ai.priority_algorithm.priority.priority import (
     RequirementPriority,
     DiversityPriority,
+    TokenizationPriority,
 )
-from api.models.enums import RequirementOperator, RequirementsCriteria, DiversifyType
+from api.models.enums import (
+    RequirementOperator,
+    RequirementsCriteria,
+    DiversifyType,
+    TokenizationConstraintDirection,
+)
 from api.models.project import ProjectRequirement
 from api.models.student import Student
 from api.models.team import TeamShell
+
+
+class TestTokenizationPriority(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.trivial_team_shell = TeamShell(_id=1)
+        cls.tokenized_attribute = 1
+        cls.tokenized_attribute_value = 4
+        cls.student_a = Student(
+            _id=1,
+            attributes={
+                cls.tokenized_attribute: [1],
+            },
+        )
+        cls.student_b = Student(
+            _id=2,
+            attributes={
+                cls.tokenized_attribute: [2],
+            },
+        )
+        cls.student_c = Student(
+            _id=2,
+            attributes={
+                cls.tokenized_attribute: [3],
+            },
+        )
+        cls.tokenized_student = Student(
+            _id=3,
+            attributes={
+                cls.tokenized_attribute: [cls.tokenized_attribute_value],
+            },
+        )
+
+    def test_satisfaction__diversify_with_min_of_tokenization(self):
+        tokenization_priority = TokenizationPriority(
+            attribute_id=self.tokenized_attribute,
+            strategy=DiversifyType.DIVERSIFY,
+            threshold=2,
+            direction=TokenizationConstraintDirection.MIN_OF,
+            value=self.tokenized_attribute_value,
+        )
+
+        high_satisfaction = tokenization_priority.satisfaction(
+            [
+                self.student_a,
+                self.student_b,
+                self.tokenized_student,
+                self.tokenized_student,
+            ],
+            self.trivial_team_shell,
+        )
+        medium_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_b, self.student_c], self.trivial_team_shell
+        )
+        medium_satisfaction_2 = tokenization_priority.satisfaction(
+            [self.tokenized_student, self.tokenized_student, self.tokenized_student],
+            self.trivial_team_shell,
+        )
+        low_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_a, self.student_a], self.trivial_team_shell
+        )
+        lowest_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_b, self.tokenized_student],
+            self.trivial_team_shell,
+        )
+
+        self.assertGreaterEqual(high_satisfaction, medium_satisfaction)
+        self.assertGreater(high_satisfaction, medium_satisfaction_2)
+        self.assertGreater(medium_satisfaction, low_satisfaction)
+        self.assertGreater(medium_satisfaction_2, lowest_satisfaction)
+        self.assertGreater(low_satisfaction, lowest_satisfaction)
+
+    def test_satisfaction__concentrate_with_max_of_tokenization(self):
+        tokenization_priority = TokenizationPriority(
+            attribute_id=self.tokenized_attribute,
+            strategy=DiversifyType.CONCENTRATE,
+            threshold=2,
+            direction=TokenizationConstraintDirection.MAX_OF,
+            value=self.tokenized_attribute_value,
+        )
+
+        high_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_a, self.student_a], self.trivial_team_shell
+        )
+        medium_satisfaction = tokenization_priority.satisfaction(
+            [
+                self.student_a,
+                self.student_a,
+                self.tokenized_student,
+                self.tokenized_student,
+            ],
+            self.trivial_team_shell,
+        )
+        low_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_b, self.student_c], self.trivial_team_shell
+        )
+        lowest_satisfaction = tokenization_priority.satisfaction(
+            [
+                self.student_a,
+                self.tokenized_student,
+                self.tokenized_student,
+                self.tokenized_student,
+            ],
+            self.trivial_team_shell,
+        )
+
+        self.assertGreaterEqual(high_satisfaction, medium_satisfaction)
+        self.assertGreater(medium_satisfaction, low_satisfaction)
+        self.assertGreater(low_satisfaction, lowest_satisfaction)
 
 
 class TestRequirementPriority(unittest.TestCase):


### PR DESCRIPTION
closes #223

Tokenization priority is no longer a binary check. This change allows the nuance of generally still caring about diversity of teams, but putting extra focus on not tokenizing students.