### PR TITLE
utils for displaying team sets

### DIFF
--- a/api/ai/priority_algorithm/priority/priority.py
+++ b/api/ai/priority_algorithm/priority/priority.py
@@ -38,11 +38,15 @@ class TokenizationPriority(Priority):
 
     def satisfaction(self, students: List[Student], team_shell: TeamShell) -> float:
         blau_index = _blau_index(students, self.attribute_id)
-        general_diversity = blau_index if self.strategy == DiversifyType.DIVERSIFY else (1 - blau_index)
+        general_diversity = (
+            blau_index if self.strategy == DiversifyType.DIVERSIFY else (1 - blau_index)
+        )
 
         tokenized_student_count = 0
         for student in students:
-            tokenized_student_count += self.value in student.attributes.get(self.attribute_id, [])
+            tokenized_student_count += self.value in student.attributes.get(
+                self.attribute_id, []
+            )
         meets_threshold = self.student_count_meets_threshold(tokenized_student_count)
 
         if not meets_threshold:

--- a/api/ai/priority_algorithm/priority_algorithm.py
+++ b/api/ai/priority_algorithm/priority_algorithm.py
@@ -41,12 +41,12 @@ class PriorityAlgorithm(Algorithm):
             team_generation_options=self.team_generation_options,
         ).generate(students)
 
-        # keep internal self.teams accurate
-        self.teams = team_set.teams
-
         return PriorityTeamSet(
             priority_teams=[
-                PriorityTeam(team_shell=team, student_ids=[s.id for s in team.students])
+                PriorityTeam(
+                    team_shell=team.to_shell(),
+                    student_ids=[s.id for s in team.students],
+                )
                 for team in team_set.teams
             ]
         )
@@ -101,10 +101,6 @@ class PriorityAlgorithm(Algorithm):
     def _unpack_priority_team_set(self, priority_team_set: PriorityTeamSet) -> TeamSet:
         teams: List[Team] = []
 
-        # empty underlying teams
-        for priority_team in priority_team_set.priority_teams:
-            priority_team.team_shell.empty()
-
         # students will be assigned a .team from the generate_initial_teams(), this must be removed
         for student in self.student_dict.values():
             student.team = None
@@ -114,8 +110,9 @@ class PriorityAlgorithm(Algorithm):
                 self.student_dict[student_id]
                 for student_id in priority_team.student_ids
             ]
-            save_students_to_team(priority_team.team_shell, students)
-            teams.append(priority_team.team_shell)
+            team = Team.from_shell(priority_team.team_shell)
+            save_students_to_team(team, students)
+            teams.append(team)
 
         return TeamSet(teams=teams)
 

--- a/api/models/team/model.py
+++ b/api/models/team/model.py
@@ -67,6 +67,15 @@ class Team(TeamShell):
             is_locked=shell.is_locked,
         )
 
+    def to_shell(self) -> TeamShell:
+        return TeamShell(
+            _id=self.id,
+            name=self.name,
+            project_id=self.project_id,
+            requirements=self.requirements,
+            is_locked=self.is_locked,
+        )
+
     def empty(self):
         for student in self.students:
             student.team = None

--- a/benchmarking/evaluations/metrics/priority_satisfaction.py
+++ b/benchmarking/evaluations/metrics/priority_satisfaction.py
@@ -47,9 +47,7 @@ class PrioritySatisfaction(TeamSetMetric):
 
     def priorities_satisfied(self, team: Team) -> List[float]:
         satisfied = [
-            # fixme: passes an instance of Team to TeamShell without converting,
-            #   this should be safe but should be handled properly eventually
-            priority.satisfaction(team.students, team)
+            priority.satisfaction(team.students, team.to_shell())
             for priority in self.priorities
         ]
         return satisfied

--- a/benchmarking/runs/diversify_gender_min_2.py
+++ b/benchmarking/runs/diversify_gender_min_2.py
@@ -13,21 +13,20 @@ from api.ai.priority_algorithm.mutations import (
     mutate_local_max,
     mutate_random_swap,
 )
-from benchmarking.evaluations.goals import DiversityGoal
-from benchmarking.evaluations.graphing.graph_metadata import GraphData, GraphAxisRange
-from benchmarking.evaluations.graphing.line_graph import line_graph
-from benchmarking.evaluations.graphing.line_graph_metadata import LineGraphMetadata
-from benchmarking.evaluations.interfaces import TeamSetMetric
-from benchmarking.evaluations.metrics.maximum_gini_index import MaximumGiniIndex
-from benchmarking.evaluations.metrics.minimum_gini_index import MinimumGiniIndex
 from api.models.enums import ScenarioAttribute, Gender, AlgorithmType
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,
     MockStudentProviderSettings,
 )
+from benchmarking.evaluations.graphing.graph_metadata import GraphData, GraphAxisRange
+from benchmarking.evaluations.graphing.line_graph import line_graph
+from benchmarking.evaluations.graphing.line_graph_metadata import LineGraphMetadata
+from benchmarking.evaluations.interfaces import TeamSetMetric
 from benchmarking.evaluations.metrics.average_gini_index import (
     AverageGiniIndex,
 )
+from benchmarking.evaluations.metrics.maximum_gini_index import MaximumGiniIndex
+from benchmarking.evaluations.metrics.minimum_gini_index import MinimumGiniIndex
 from benchmarking.evaluations.metrics.priority_satisfaction import PrioritySatisfaction
 from benchmarking.evaluations.scenarios.diversify_gender_min_2_female import (
     DiversifyGenderMin2Female,
@@ -72,9 +71,7 @@ class DiversifyGenderMin2Run(Run):
             "MaxGiniIndex": MaximumGiniIndex(attribute=ScenarioAttribute.GENDER.value),
             "MinGiniIndex": MinimumGiniIndex(attribute=ScenarioAttribute.GENDER.value),
             "PrioritySatisfaction": PrioritySatisfaction(
-                goals_to_priorities(
-                    [goal for goal in scenario.goals if isinstance(goal, DiversityGoal)]
-                ),
+                goals_to_priorities(scenario.goals),
                 False,
             ),
         }

--- a/benchmarking/runs/three_tokenization_constraints.py
+++ b/benchmarking/runs/three_tokenization_constraints.py
@@ -85,9 +85,7 @@ class ThreeTokenizationConstraintsRun(Run):
                 ]
             ),
             "PrioritySatisfaction": PrioritySatisfaction(
-                goals_to_priorities(
-                    [goal for goal in scenario.goals if isinstance(goal, DiversityGoal)]
-                ),
+                goals_to_priorities(scenario.goals),
                 False,
             ),
         }

--- a/benchmarking/simulation/goal_to_priority.py
+++ b/benchmarking/simulation/goal_to_priority.py
@@ -11,7 +11,13 @@ from benchmarking.evaluations.interfaces import Goal
 
 
 def goals_to_priorities(goals: List[Goal]) -> List[Priority]:
-    return [goal_to_priority(goal) for goal in goals]
+    priorities = []
+    for goal in goals:
+        try:
+            priorities.append(goal_to_priority(goal))
+        except NotImplementedError:
+            continue
+    return priorities
 
 
 def goal_to_priority(goal: Goal) -> Priority:

--- a/benchmarking/simulation/simulation.py
+++ b/benchmarking/simulation/simulation.py
@@ -74,7 +74,7 @@ class Simulation:
             students = self.settings.student_provider.get()
 
             start_time = time.time()
-            team_set = runner.generate(copy.deepcopy(students))
+            team_set = runner.generate(students)
             end_time = time.time()
 
             self.run_times.append(end_time - start_time)

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority/test_priority.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority/test_priority.py
@@ -3,11 +3,126 @@ import unittest
 from api.ai.priority_algorithm.priority.priority import (
     RequirementPriority,
     DiversityPriority,
+    TokenizationPriority,
 )
-from api.models.enums import RequirementOperator, RequirementsCriteria, DiversifyType
+from api.models.enums import (
+    RequirementOperator,
+    RequirementsCriteria,
+    DiversifyType,
+    TokenizationConstraintDirection,
+)
 from api.models.project import ProjectRequirement
 from api.models.student import Student
 from api.models.team import TeamShell
+
+
+class TestTokenizationPriority(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.trivial_team_shell = TeamShell(_id=1)
+        cls.tokenized_attribute = 1
+        cls.tokenized_attribute_value = 4
+        cls.student_a = Student(
+            _id=1,
+            attributes={
+                cls.tokenized_attribute: [1],
+            },
+        )
+        cls.student_b = Student(
+            _id=2,
+            attributes={
+                cls.tokenized_attribute: [2],
+            },
+        )
+        cls.student_c = Student(
+            _id=2,
+            attributes={
+                cls.tokenized_attribute: [3],
+            },
+        )
+        cls.tokenized_student = Student(
+            _id=3,
+            attributes={
+                cls.tokenized_attribute: [cls.tokenized_attribute_value],
+            },
+        )
+
+    def test_satisfaction__diversify_with_min_of_tokenization(self):
+        tokenization_priority = TokenizationPriority(
+            attribute_id=self.tokenized_attribute,
+            strategy=DiversifyType.DIVERSIFY,
+            threshold=2,
+            direction=TokenizationConstraintDirection.MIN_OF,
+            value=self.tokenized_attribute_value,
+        )
+
+        high_satisfaction = tokenization_priority.satisfaction(
+            [
+                self.student_a,
+                self.student_b,
+                self.tokenized_student,
+                self.tokenized_student,
+            ],
+            self.trivial_team_shell,
+        )
+        medium_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_b, self.student_c], self.trivial_team_shell
+        )
+        medium_satisfaction_2 = tokenization_priority.satisfaction(
+            [self.tokenized_student, self.tokenized_student, self.tokenized_student],
+            self.trivial_team_shell,
+        )
+        low_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_a, self.student_a], self.trivial_team_shell
+        )
+        lowest_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_b, self.tokenized_student],
+            self.trivial_team_shell,
+        )
+
+        self.assertGreaterEqual(high_satisfaction, medium_satisfaction)
+        self.assertGreater(high_satisfaction, medium_satisfaction_2)
+        self.assertGreater(medium_satisfaction, low_satisfaction)
+        self.assertGreater(medium_satisfaction_2, lowest_satisfaction)
+        self.assertGreater(low_satisfaction, lowest_satisfaction)
+
+    def test_satisfaction__concentrate_with_max_of_tokenization(self):
+        tokenization_priority = TokenizationPriority(
+            attribute_id=self.tokenized_attribute,
+            strategy=DiversifyType.CONCENTRATE,
+            threshold=2,
+            direction=TokenizationConstraintDirection.MAX_OF,
+            value=self.tokenized_attribute_value,
+        )
+
+        high_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_a, self.student_a], self.trivial_team_shell
+        )
+        medium_satisfaction = tokenization_priority.satisfaction(
+            [
+                self.student_a,
+                self.student_a,
+                self.tokenized_student,
+                self.tokenized_student,
+            ],
+            self.trivial_team_shell,
+        )
+        low_satisfaction = tokenization_priority.satisfaction(
+            [self.student_a, self.student_b, self.student_c], self.trivial_team_shell
+        )
+        lowest_satisfaction = tokenization_priority.satisfaction(
+            [
+                self.student_a,
+                self.tokenized_student,
+                self.tokenized_student,
+                self.tokenized_student,
+            ],
+            self.trivial_team_shell,
+        )
+
+        self.assertGreaterEqual(high_satisfaction, medium_satisfaction)
+        self.assertGreater(medium_satisfaction, low_satisfaction)
+        self.assertGreater(low_satisfaction, lowest_satisfaction)
 
 
 class TestRequirementPriority(unittest.TestCase):

--- a/utils/visibility.py
+++ b/utils/visibility.py
@@ -8,8 +8,18 @@ def show_team_set(team_set: TeamSet, highlight_students_by: Callable):
     print(team_set.id)
     for team in team_set.teams:
         print("\t" + str(team.id))
-        print("\t\t" + str([f"{s.id}{'*' if highlight_students_by(s) else ''}" for s in team.students]))
+        print(
+            "\t\t"
+            + str(
+                [
+                    f"{s.id}{'*' if highlight_students_by(s) else ''}"
+                    for s in team.students
+                ]
+            )
+        )
 
 
-def highlight_with_attribute_value(student: Student, attribute_id: int, value: int) -> bool:
+def highlight_with_attribute_value(
+    student: Student, attribute_id: int, value: int
+) -> bool:
     return value in student.attributes.get(attribute_id, [])

--- a/utils/visibility.py
+++ b/utils/visibility.py
@@ -1,0 +1,15 @@
+from typing import Callable
+
+from api.models.student import Student
+from api.models.team_set import TeamSet
+
+
+def show_team_set(team_set: TeamSet, highlight_students_by: Callable):
+    print(team_set.id)
+    for team in team_set.teams:
+        print("\t" + str(team.id))
+        print("\t\t" + str([f"{s.id}{'*' if highlight_students_by(s) else ''}" for s in team.students]))
+
+
+def highlight_with_attribute_value(student: Student, attribute_id: int, value: int) -> bool:
+    return value in student.attributes.get(attribute_id, [])


### PR DESCRIPTION
Changes

- added a small util for displaying team set overviews and marking students based on any criteria you want
- fully resolved the switch to using team shells for priority teams (proper conversion back and forth)
- made `goal_to_priority()` dynamically handle new support to priorities