### PR TITLE
remove match_skills from requirement priority

### DIFF
--- a/benchmarking/evaluations/goals.py
+++ b/benchmarking/evaluations/goals.py
@@ -37,16 +37,9 @@ class PreferenceGoal(Goal):
 
 @dataclass
 class ProjectRequirementGoal(Goal):
-    match_skills: bool
     criteria: Optional[
         RequirementsCriteria
     ] = RequirementsCriteria.PROJECT_REQUIREMENTS_ARE_SATISFIED
-
-    def validate(self):
-        if not self.match_skills and self.criteria:
-            raise ValueError(
-                "If skills are not being matched at all, no matching criteria can be set!"
-            )
 
 
 @dataclass

--- a/benchmarking/simulation/goal_to_priority.py
+++ b/benchmarking/simulation/goal_to_priority.py
@@ -33,7 +33,7 @@ def goal_to_priority(goal: Goal) -> Priority:
             direction=goal.direction,
         )
 
-    if isinstance(goal, ProjectRequirementGoal) and goal.match_skills:
+    if isinstance(goal, ProjectRequirementGoal):
         return RequirementPriority(
             criteria=goal.criteria,
         )

--- a/benchmarking/simulation/mock_algorithm.py
+++ b/benchmarking/simulation/mock_algorithm.py
@@ -115,7 +115,7 @@ class MockAlgorithm:
                 else:
                     attributes_to_concentrate.append(goal.attribute)
             if isinstance(goal, ProjectRequirementGoal):
-                has_project_requirement_goal = goal.match_skills
+                has_project_requirement_goal = True
 
         if not has_weight_goal:
             # set default weights if no weights are explicitly given in the scenario


### PR DESCRIPTION
Unnecessary, if you don't want a requirement goal to match skills then you simply wouldn't include a requirement goal