### PR TITLE
mock student generator bug fix

### DIFF
--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -105,22 +105,32 @@ def create_mock_students(
     f = number_of_friends
     e = number_of_enemies
 
+    if number_of_friends + number_of_enemies >= number_of_students:
+        raise ValueError(
+            "Cannot request more friends/enemies than there are people in the class"
+        )
+
     for i in range(n):
         relationships = {}
-        for j in range(f + 1):
-            # todo: (document) this doesn't guarantee the friend/enemy count, just sets the max
-            if friend_distribution == "cluster":
-                friend_id = (i // (f + 1) * (f + 1) + j) % n
-            else:
-                friend_id = random.randrange(0, n)
-            if friend_id == i:
-                continue
+
+        # Pick friends
+        if friend_distribution == "cluster":
+            clique_start = i // (f + 1) * (f + 1)
+            friends = [
+                friend_id % n
+                for friend_id in range(clique_start, clique_start + f + 1)
+                if friend_id != i
+            ]
+        else:
+            other_people = [_ for _ in range(0, n) if _ != i]
+            friends = random.sample(other_people, min(f, len(other_people)))
+        for friend_id in friends:
             relationships[friend_id] = Relationship.FRIEND
-        for j in range(e):
-            while True:
-                enemy_id = random.randrange(0, n)
-                if enemy_id not in relationships:
-                    break
+
+        # Pick enemies
+        eligible_enemies = [_ for _ in range(0, n) if _ not in [i, *friends]]
+        enemies = random.sample(eligible_enemies, min(e, len(eligible_enemies)))
+        for enemy_id in enemies:
             relationships[enemy_id] = Relationship.ENEMY
 
         attributes = {}

--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -107,17 +107,20 @@ def create_mock_students(
 
     for i in range(n):
         relationships = {}
-        for j in range(f):
+        for j in range(f + 1):
             # todo: (document) this doesn't guarantee the friend/enemy count, just sets the max
             if friend_distribution == "cluster":
-                friend_id = (i // f * f + j) % n
+                friend_id = (i // (f + 1) * (f + 1) + j) % n
             else:
                 friend_id = random.randrange(0, n)
             if friend_id == i:
                 continue
             relationships[friend_id] = Relationship.FRIEND
         for j in range(e):
-            enemy_id = random.randrange(0, n)
+            while True:
+                enemy_id = random.randrange(0, n)
+                if enemy_id not in relationships:
+                    break
             relationships[enemy_id] = Relationship.ENEMY
 
         attributes = {}

--- a/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
+++ b/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
@@ -21,6 +21,76 @@ class TestMockStudentProvider(unittest.TestCase):
         for student in students:
             self.assertIsInstance(student, Student)
 
+    def test_get__each_student_has_correct_num_friends_and_enemies(self):
+        students = MockStudentProvider(
+            MockStudentProviderSettings(
+                number_of_students=10,
+                number_of_friends=4,
+                number_of_enemies=1,
+            )
+        ).get()
+
+        for student in students:
+            num_friends = len(
+                [
+                    1
+                    for stu_id, relation in student.relationships.items()
+                    if relation == Relationship.FRIEND
+                ]
+            )
+            num_enemies = len(
+                [
+                    1
+                    for stu_id, relation in student.relationships.items()
+                    if relation == Relationship.ENEMY
+                ]
+            )
+
+            self.assertEqual(4, num_friends)
+            self.assertEqual(1, num_enemies)
+
+    def test_get__each_student_has_correct_num_friends_and_enemies_non_divisible_class_size(
+        self,
+    ):
+        students = MockStudentProvider(
+            MockStudentProviderSettings(
+                number_of_students=10,
+                number_of_friends=3,
+                number_of_enemies=1,
+            )
+        ).get()
+
+        for student in students:
+            num_friends = len(
+                [
+                    1
+                    for stu_id, relation in student.relationships.items()
+                    if relation == Relationship.FRIEND
+                ]
+            )
+            num_enemies = len(
+                [
+                    1
+                    for stu_id, relation in student.relationships.items()
+                    if relation == Relationship.ENEMY
+                ]
+            )
+
+            self.assertEqual(3, num_friends)
+            self.assertEqual(1, num_enemies)
+
+    def test_get__class_size_too_small(self):
+        self.assertRaises(
+            ValueError,
+            lambda: MockStudentProvider(
+                MockStudentProviderSettings(
+                    number_of_students=2,
+                    number_of_friends=4,
+                    number_of_enemies=1,
+                )
+            ).get(),
+        )
+
     def test_max_project_preferences__are_correctly_inferred(self):
         max_project_preferences_1 = MockStudentProvider(
             MockStudentProviderSettings(
@@ -105,7 +175,7 @@ class TestMockStudentProviderHelpers(unittest.TestCase):
     def test_create_mock_students__students_have_correct_friend_and_enemy_count(self):
         for i in [1, 5, 10]:
             students = create_mock_students(
-                number_of_students=i + 1,
+                number_of_students=i * 2 + 1,
                 number_of_friends=i,
                 number_of_enemies=i,
                 friend_distribution="random",

--- a/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
+++ b/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Literal, List
 
 from api.models.enums import Gpa, ScenarioAttribute, Relationship
 from api.models.student import Student
@@ -20,76 +21,6 @@ class TestMockStudentProvider(unittest.TestCase):
 
         for student in students:
             self.assertIsInstance(student, Student)
-
-    def test_get__each_student_has_correct_num_friends_and_enemies(self):
-        students = MockStudentProvider(
-            MockStudentProviderSettings(
-                number_of_students=10,
-                number_of_friends=4,
-                number_of_enemies=1,
-            )
-        ).get()
-
-        for student in students:
-            num_friends = len(
-                [
-                    1
-                    for stu_id, relation in student.relationships.items()
-                    if relation == Relationship.FRIEND
-                ]
-            )
-            num_enemies = len(
-                [
-                    1
-                    for stu_id, relation in student.relationships.items()
-                    if relation == Relationship.ENEMY
-                ]
-            )
-
-            self.assertEqual(4, num_friends)
-            self.assertEqual(1, num_enemies)
-
-    def test_get__each_student_has_correct_num_friends_and_enemies_non_divisible_class_size(
-        self,
-    ):
-        students = MockStudentProvider(
-            MockStudentProviderSettings(
-                number_of_students=10,
-                number_of_friends=3,
-                number_of_enemies=1,
-            )
-        ).get()
-
-        for student in students:
-            num_friends = len(
-                [
-                    1
-                    for stu_id, relation in student.relationships.items()
-                    if relation == Relationship.FRIEND
-                ]
-            )
-            num_enemies = len(
-                [
-                    1
-                    for stu_id, relation in student.relationships.items()
-                    if relation == Relationship.ENEMY
-                ]
-            )
-
-            self.assertEqual(3, num_friends)
-            self.assertEqual(1, num_enemies)
-
-    def test_get__class_size_too_small(self):
-        self.assertRaises(
-            ValueError,
-            lambda: MockStudentProvider(
-                MockStudentProviderSettings(
-                    number_of_students=2,
-                    number_of_friends=4,
-                    number_of_enemies=1,
-                )
-            ).get(),
-        )
 
     def test_max_project_preferences__are_correctly_inferred(self):
         max_project_preferences_1 = MockStudentProvider(
@@ -205,6 +136,156 @@ class TestMockStudentProviderHelpers(unittest.TestCase):
                         ]
                     ),
                 )
+
+    def test_create_mock_students__each_student_has_correct_num_friends_and_enemies(
+        self,
+    ):
+        dist_types: List[Literal["random", "cluster"]] = ["random", "cluster"]
+        for dist_type in dist_types:
+            students = create_mock_students(
+                number_of_students=10,
+                number_of_friends=4,
+                number_of_enemies=2,
+                friend_distribution=dist_type,
+                attribute_ranges={},
+                num_values_per_attribute={},
+                project_preference_options=[],
+                num_project_preferences_per_student=0,
+            )
+
+            for student in students:
+                num_friends = len(
+                    [
+                        1
+                        for stu_id, relation in student.relationships.items()
+                        if relation == Relationship.FRIEND
+                    ]
+                )
+                num_enemies = len(
+                    [
+                        1
+                        for stu_id, relation in student.relationships.items()
+                        if relation == Relationship.ENEMY
+                    ]
+                )
+
+                self.assertEqual(4, num_friends)
+                self.assertEqual(2, num_enemies)
+
+    def test_create_mock_students__each_student_has_correct_num_friends_and_enemies_non_divisible_class_size(
+        self,
+    ):
+        dist_types: List[Literal["random", "cluster"]] = ["random", "cluster"]
+        for dist_type in dist_types:
+            students = create_mock_students(
+                number_of_students=10,
+                number_of_friends=3,
+                number_of_enemies=2,
+                friend_distribution=dist_type,
+                attribute_ranges={},
+                num_values_per_attribute={},
+                project_preference_options=[],
+                num_project_preferences_per_student=0,
+            )
+
+            for student in students:
+                num_friends = len(
+                    [
+                        1
+                        for stu_id, relation in student.relationships.items()
+                        if relation == Relationship.FRIEND
+                    ]
+                )
+                num_enemies = len(
+                    [
+                        1
+                        for stu_id, relation in student.relationships.items()
+                        if relation == Relationship.ENEMY
+                    ]
+                )
+
+                self.assertEqual(3, num_friends)
+                self.assertEqual(2, num_enemies)
+
+    def test_create_mock_students__class_size_too_small(self):
+        self.assertRaises(
+            ValueError,
+            lambda: create_mock_students(
+                number_of_students=2,
+                number_of_friends=4,
+                number_of_enemies=1,
+                friend_distribution="random",
+                attribute_ranges={},
+                num_values_per_attribute={},
+                project_preference_options=[],
+                num_project_preferences_per_student=0,
+            ),
+        )
+
+    def test_create_mock_students__friend_cannot_be_enemy(self):
+        dist_types: List[Literal["random", "cluster"]] = ["random", "cluster"]
+        for dist_type in dist_types:
+            students = create_mock_students(
+                number_of_students=10,
+                number_of_friends=3,
+                number_of_enemies=2,
+                friend_distribution=dist_type,
+                attribute_ranges={},
+                num_values_per_attribute={},
+                project_preference_options=[],
+                num_project_preferences_per_student=0,
+            )
+
+            for student in students:
+                friends = [
+                    friend_id
+                    for friend_id, relation in student.relationships.items()
+                    if relation == Relationship.FRIEND
+                ]
+                enemies = [
+                    enemy_id
+                    for enemy_id, relation in student.relationships.items()
+                    if relation == Relationship.ENEMY
+                ]
+
+                for friend in friends:
+                    self.assertNotIn(friend, enemies)
+
+    def test_create_mock_students__cluster_setting_returns_clustered_students(self):
+        students = create_mock_students(
+            number_of_students=12,
+            number_of_friends=3,
+            number_of_enemies=2,
+            friend_distribution="cluster",
+            attribute_ranges={},
+            num_values_per_attribute={},
+            project_preference_options=[],
+            num_project_preferences_per_student=0,
+        )
+
+        cliques: List[List[int]] = []
+        for student in students:
+            friends = [
+                friend_id
+                for friend_id, relation in student.relationships.items()
+                if relation == Relationship.FRIEND
+            ]
+
+            # Check if current student is assigned to a clique yet
+            my_clique = None
+            for clique in cliques:
+                if student.id in clique:
+                    my_clique = clique
+                    break
+
+            if my_clique:
+                # Check that clique contains all friends
+                self.assertTrue(all([friend in my_clique for friend in friends]))
+            else:
+                # If not in clique yet, create one
+                cliques.append([student.id, *friends])
+
+        self.assertEqual(3, len(cliques))
 
     def test_random_choice__always_returns_list_of_int(self):
         values_1 = random_choice(possible_values=[1, 2, 3], size=1)


### PR DESCRIPTION
Closes #232 
Description in issue. Reasoning for fix is that since specifying 2 enemies creates two enemy relationships on each student, specifying 2 friends should also do the same. The old behaviour is that each student would be a part of a clique of 2, rather than have 2 friends