### PR TITLE
Fix calculation of max_team_size

### DIFF
--- a/benchmarking/simulation/mock_algorithm.py
+++ b/benchmarking/simulation/mock_algorithm.py
@@ -39,8 +39,11 @@ class MockAlgorithm:
     ) -> TeamGenerationOptions:
         _num_teams = len(initial_teams) if initial_teams else num_teams
         min_team_size = num_students // _num_teams
+        max_team_size = (
+            min_team_size if num_students % _num_teams == 0 else min_team_size + 1
+        )
         return TeamGenerationOptions(
-            max_team_size=min_team_size + 1,
+            max_team_size=max_team_size,
             min_team_size=min_team_size,
             total_teams=_num_teams,
             initial_teams=initial_teams,


### PR DESCRIPTION
## Problem
The social algorithm finds cliques of students up to a clique size of `max_team_size`. The problem is that `max_team_size` is not being calculated correctly. It assumed that `num_students` is not evenly divisible by `num_teams`. The result is that `max_team_size` is one too big in the case that it is evenly divisible and social was finding cliques that were too big.

Closes #264 