### PR TITLE
Use the correct number of friends for social runs

### DIFF
--- a/benchmarking/runs/social/varied_class_size.py
+++ b/benchmarking/runs/social/varied_class_size.py
@@ -35,7 +35,7 @@ class VariedClassSizeSocialRun(SocialRun):
 
             student_provider_settings = MockStudentProviderSettings(
                 number_of_students=class_size,
-                number_of_friends=5,
+                number_of_friends=4,
                 number_of_enemies=2,
                 friend_distribution="cluster",
             )

--- a/benchmarking/runs/social/varied_num_enemies.py
+++ b/benchmarking/runs/social/varied_num_enemies.py
@@ -39,7 +39,7 @@ class VariedNumEnemiesSocialRun(SocialRun):
 
             student_provider_settings = MockStudentProviderSettings(
                 number_of_students=250,
-                number_of_friends=5,
+                number_of_friends=4,
                 number_of_enemies=num_enemies,
                 friend_distribution="cluster",
             )


### PR DESCRIPTION
I done goofed this one, silly mistake. It was intended for the clique size to be equal to the team size, which is 5 for these two runs

Closes #266 