### PR TITLE
fix tests

### DIFF
--- a/api/models/team_set/model.py
+++ b/api/models/team_set/model.py
@@ -6,7 +6,7 @@ from api.models.team import Team
 
 @dataclass
 class TeamSet:
-    _id: int = None
+    _id: str = None
     name: str = None
     teams: List[Team] = field(default_factory=list)
 

--- a/benchmarking/simulation/simulation.py
+++ b/benchmarking/simulation/simulation.py
@@ -39,6 +39,17 @@ class Simulation:
         self.run_times = []
 
     def run(self, num_runs: int) -> SimulationArtifact:
+        if self.settings.cache_key:
+            cache = SimulationCache(self.settings.cache_key)
+            if cache.exists():
+                cached_team_sets, cached_run_times = cache.get_simulation_artifact()
+                self.team_sets = cached_team_sets
+                self.run_times = cached_run_times
+                if len(self.team_sets) >= num_runs:
+                    return self.team_sets[:num_runs], self.run_times[:num_runs]
+                else:
+                    num_runs -= len(cached_team_sets)
+
         custom_initial_teams = (
             self.settings.initial_teams_provider.get()
             if self.settings.initial_teams_provider
@@ -60,17 +71,6 @@ class Simulation:
             algorithm_options=algorithm_options,
             algorithm_config=self.config,
         )
-
-        if self.settings.cache_key:
-            cache = SimulationCache(self.settings.cache_key)
-            if cache.exists():
-                cached_team_sets, cached_run_times = cache.get_simulation_artifact()
-                self.team_sets = cached_team_sets
-                self.run_times = cached_run_times
-                if len(self.team_sets) >= num_runs:
-                    return self.team_sets[:num_runs], self.run_times[:num_runs]
-                else:
-                    num_runs -= len(cached_team_sets)
 
         if self.settings.cache_key:
             SimulationCache.create_fragment_parent_dir(self.settings.cache_key)

--- a/tests/test_benchmarking/test_simulation/test_simulation.py
+++ b/tests/test_benchmarking/test_simulation/test_simulation.py
@@ -1,7 +1,7 @@
 import json
 import shutil
 import unittest
-from datetime import time, datetime
+from datetime import datetime
 from os import path
 
 from api.ai.interfaces.algorithm_config import PriorityAlgorithmConfig
@@ -206,8 +206,18 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(2, len(new_simulation_result[1]))
 
         self.assertEqual(
-            simplify_simulation_result(simulation_result),
-            simplify_simulation_result(new_simulation_result),
+            simplify_simulation_result(
+                (
+                    sorted(simulation_result[0], key=lambda x: x._id),
+                    sorted(simulation_result[1]),
+                )
+            ),
+            simplify_simulation_result(
+                (
+                    sorted(new_simulation_result[0], key=lambda x: x._id),
+                    sorted(new_simulation_result[1]),
+                )
+            ),
         )
 
     def test_run__return_only_num_runs_number_of_run_outputs(self):


### PR DESCRIPTION
The problem is that the cache returns results in order of timestamp, but the output from the simulation run that creates the cache returns in order of fragment id.

Depending on how long it takes processes to spin up, there is no guarantee that the timestamp order matches the fragment id order, thus creating a flaky test.