### PR TITLE
Fix API not response with a correct error message

### DIFF
--- a/api/api/utils/response_with_metadata.py
+++ b/api/api/utils/response_with_metadata.py
@@ -18,7 +18,7 @@ class ResponseWithMetadata(Response):
     ):
         super().__init__(data, status, template_name, headers, exception, content_type)
 
-        data_label = data_label if data_label else "data"
+        data_label = data_label if data_label else "teams"
         self.data = {
             data_label: self.data,
             "metadata": {

--- a/api/api/views/generate_teams.py
+++ b/api/api/views/generate_teams.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.decorators import action
+from schema import SchemaError
 
 from api.ai.algorithm_runner import AlgorithmRunner
 from api.api.utils.generate_teams_data_loader import GenerateTeamsDataLoader
@@ -26,21 +27,30 @@ class GenerateTeamsViewSet(viewsets.GenericViewSet):
         5. Serialize algorithm's output (TeamSet) to JSON
         6. Return JSON to a happy user :) 🚀!
         """
-        request_data = dict(request.data)
+        try:
+            request_data = dict(request.data)
 
-        # validate data schema
-        GenerateTeamsValidator(request_data).validate()
-        input_data = GenerateTeamsDataLoader(request_data).load()
+            # validate data schema
+            GenerateTeamsValidator(request_data).validate()
+            input_data = GenerateTeamsDataLoader(request_data).load()
 
-        runner = AlgorithmRunner(
-            algorithm_type=input_data.algorithm_type,
-            team_generation_options=input_data.team_generation_options,
-            algorithm_options=input_data.algorithm_options,
-            algorithm_config=None,
-        )
-        team_set = runner.generate(input_data.students)
+            runner = AlgorithmRunner(
+                algorithm_type=input_data.algorithm_type,
+                team_generation_options=input_data.team_generation_options,
+                algorithm_options=input_data.algorithm_options,
+                algorithm_config=None,
+            )
+            team_set = runner.generate(input_data.students)
 
-        serialized_team_set = TeamSetSerializer().default(team_set)
-        return ResponseWithMetadata(
-            data_label="teams", data=serialized_team_set, status=200
-        )
+            serialized_team_set = TeamSetSerializer().default(team_set)
+            return ResponseWithMetadata(
+                data=serialized_team_set, status=200
+            )
+        except SchemaError as e:
+            return ResponseWithMetadata(
+                error=str(e), status=400
+            )
+        except Exception as e:
+            return ResponseWithMetadata(
+                error=str(e), status=500
+            )

--- a/api/api/views/generate_teams.py
+++ b/api/api/views/generate_teams.py
@@ -43,14 +43,8 @@ class GenerateTeamsViewSet(viewsets.GenericViewSet):
             team_set = runner.generate(input_data.students)
 
             serialized_team_set = TeamSetSerializer().default(team_set)
-            return ResponseWithMetadata(
-                data=serialized_team_set, status=200
-            )
+            return ResponseWithMetadata(data=serialized_team_set, status=200)
         except SchemaError as e:
-            return ResponseWithMetadata(
-                error=str(e), status=400
-            )
+            return ResponseWithMetadata(error=str(e), status=400)
         except Exception as e:
-            return ResponseWithMetadata(
-                error=str(e), status=500
-            )
+            return ResponseWithMetadata(error=str(e), status=500)


### PR DESCRIPTION
Currently, we only return 500 when there is an error when validating the schema. We should catch the specific error and send that to the error.
Minor fix: we always have teams as the data label, so I replaced "data" with "teams"

Sample error message:
```json
{
    "teams": null,
    "metadata": {
        "version": "v0.1.0",
        "timestamp": 1702550314.0737631
    },
    "error": "Student 1 has project preferences that do not exist in the project set."
}
```