### PR TITLE
Fix MockStudentProvider validation

### DIFF
--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -1,3 +1,4 @@
+import math
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -66,16 +67,13 @@ class MockStudentProviderSettings:
                 "Cannot ensure exact attribute ratios when specifying num_values_per_attribute"
             )
 
-        if self.attribute_ranges and not isinstance(
-            self.attribute_ranges[0], (int, AttributeValueEnum)
-        ):
-            # Validate when attribute ranges are specified as a list of (value, % chance) tuples
-            for attribute_id, range_config in self.attribute_ranges.items():
-                total_chance = sum([_[1] for _ in range_config])
-                if not total_chance == 1:
-                    raise ValueError(
-                        f"attribute_ranges[{attribute_id}] must sum to 1. Found {total_chance}"
-                    )
+        # Validate when attribute ranges are specified as a list of (value, % chance) tuples
+        for attribute_id, range_config in self.attribute_ranges.items():
+            total_chance = sum([_[1] for _ in range_config])
+            if not math.isclose(total_chance, 1):
+                raise ValueError(
+                    f"attribute_ranges[{attribute_id}] must sum to 1. Found {total_chance}"
+                )
 
 
 class MockStudentProvider(StudentProvider):

--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -69,11 +69,12 @@ class MockStudentProviderSettings:
 
         # Validate when attribute ranges are specified as a list of (value, % chance) tuples
         for attribute_id, range_config in self.attribute_ranges.items():
-            total_chance = sum([_[1] for _ in range_config])
-            if not math.isclose(total_chance, 1):
-                raise ValueError(
-                    f"attribute_ranges[{attribute_id}] must sum to 1. Found {total_chance}"
-                )
+            if isinstance(range_config[0], (int, AttributeValueEnum)):
+                total_chance = sum([_[1] for _ in range_config])
+                if not math.isclose(total_chance, 1):
+                    raise ValueError(
+                        f"attribute_ranges[{attribute_id}] must sum to 1. Found {total_chance}"
+                    )
 
 
 class MockStudentProvider(StudentProvider):


### PR DESCRIPTION
- `self.attribute_ranges` has the type `Dict[int, AttributeRangeConfig]` but this is checking `self.attribute_ranges[0]`, which might not exist. We can move this down inside of the loop.
- `total_chance` is a float, so should compare with margin of error