### PR TITLE
Fix Priority Algorithm's internal scoring function for concentration

### DIFF
--- a/benchmarking/evaluations/goals.py
+++ b/benchmarking/evaluations/goals.py
@@ -24,7 +24,7 @@ class DiversityGoal(Goal):
             self.strategy == DiversifyType.CONCENTRATE
             and not self.tokenization_constraint
         ):
-            self.max_num_choices = 1  # setting the default when needed
+            self.max_num_choices = self.max_num_choices or 1  # setting the default when needed
         # calls the super method after so that the validate method is processed after this default is set
         super().__post_init__()
 

--- a/benchmarking/evaluations/goals.py
+++ b/benchmarking/evaluations/goals.py
@@ -24,7 +24,9 @@ class DiversityGoal(Goal):
             self.strategy == DiversifyType.CONCENTRATE
             and not self.tokenization_constraint
         ):
-            self.max_num_choices = self.max_num_choices or 1  # setting the default when needed
+            self.max_num_choices = (
+                self.max_num_choices or 1
+            )  # setting the default when needed
         # calls the super method after so that the validate method is processed after this default is set
         super().__post_init__()
 

--- a/benchmarking/simulation/goal_to_priority.py
+++ b/benchmarking/simulation/goal_to_priority.py
@@ -50,6 +50,7 @@ def goal_to_priority(goal: Goal) -> Priority:
             return DiversityPriority(
                 attribute_id=goal.attribute,
                 strategy=goal.strategy,
+                max_num_choices=goal.max_num_choices,
             )
 
         return TokenizationPriority(


### PR DESCRIPTION
Fix bugs from #334 

From Discord message:
> I got `{'PrioritySatisfaction': {'AlgorithmType.PRIORITY-PriorityAlgorithm': 1.0833333333333333}}`

This is caused by always defaulting max_num_choices to 1.