### PR TITLE
Allow filtering of cosine similarity to specific attributes

### DIFF
--- a/benchmarking/evaluations/metrics/cosine_similarity.py
+++ b/benchmarking/evaluations/metrics/cosine_similarity.py
@@ -59,9 +59,8 @@ class AverageCosineSimilarity(TeamSetMetric):
 
         return statistics.mean(similarities)
 
-    @staticmethod
-    def calculate_stdev(team_set: TeamSet) -> float:
-        class_attributes = ClassAttributeSet(team_set)
+    def calculate_stdev(self, team_set: TeamSet) -> float:
+        class_attributes = ClassAttributeSet(team_set, self.attribute_filter)
 
         similarities = team_cosine_similarities(team_set.teams, class_attributes)
 
@@ -122,9 +121,8 @@ class AverageCosineDifference(TeamSetMetric):
 
         return statistics.mean([1 - similarity for similarity in similarities])
 
-    @staticmethod
-    def calculate_stdev(team_set: TeamSet) -> float:
-        class_attributes = ClassAttributeSet(team_set)
+    def calculate_stdev(self, team_set: TeamSet) -> float:
+        class_attributes = ClassAttributeSet(team_set, self.attribute_filter)
 
         similarities = team_cosine_similarities(team_set.teams, class_attributes)
 

--- a/benchmarking/evaluations/metrics/cosine_similarity.py
+++ b/benchmarking/evaluations/metrics/cosine_similarity.py
@@ -12,18 +12,19 @@ from benchmarking.evaluations.interfaces import TeamSetMetric
 
 
 class ClassAttributeSet:
-    def __init__(self, team_set: TeamSet):
+    def __init__(self, team_set: TeamSet, attribute_filter: List[int] = None):
         # Dict of a (Attribute type, attribute value) to index of that combination in the vector used for cosine similarity
         self._data: Dict[Tuple[int, int], int] = {}
         index = 0
         for team in team_set.teams:
             for student in team.students:
                 for key, values in student.attributes.items():
-                    for value in values:
-                        attribute = (key, value)
-                        if attribute not in self._data:
-                            self._data[attribute] = index
-                            index += 1
+                    if attribute_filter is None or key in attribute_filter:
+                        for value in values:
+                            attribute = (key, value)
+                            if attribute not in self._data:
+                                self._data[attribute] = index
+                                index += 1
 
     def index_of(self, attribute: Tuple[int, int]) -> int:
         return self._data.get(attribute)
@@ -35,13 +36,24 @@ class ClassAttributeSet:
         v = [0] * self.size()
         for key, values in student.attributes.items():
             for value in values:
-                v[self.index_of((key, value))] = 1
+                index = self.index_of((key, value))
+                if index is not None:
+                    v[index] = 1
         return v
 
 
 class AverageCosineSimilarity(TeamSetMetric):
+    def __init__(self, attribute_filter: List[int] = None, *args, **kwargs):
+        """
+        This metric calculates the average cosine similarity between all students in a team.
+
+        :param attribute_filter: A list of attribute types to filter on. By default, all attributes are used.
+        """
+        super().__init__(*args, **kwargs)
+        self.attribute_filter = attribute_filter
+
     def calculate(self, team_set: TeamSet) -> float:
-        class_attributes = ClassAttributeSet(team_set)
+        class_attributes = ClassAttributeSet(team_set, self.attribute_filter)
 
         similarities = team_cosine_similarities(team_set.teams, class_attributes)
 
@@ -94,8 +106,17 @@ def cosine_similarity(
 
 
 class AverageCosineDifference(TeamSetMetric):
+    def __init__(self, attribute_filter: List[int] = None, *args, **kwargs):
+        """
+        This metric calculates the average cosine difference between all students in a team.
+
+        :param attribute_filter: A list of attribute types to filter on. By default, all attributes are used.
+        """
+        super().__init__(*args, **kwargs)
+        self.attribute_filter = attribute_filter
+
     def calculate(self, team_set: TeamSet) -> float:
-        class_attributes = ClassAttributeSet(team_set)
+        class_attributes = ClassAttributeSet(team_set, self.attribute_filter)
 
         similarities = team_cosine_similarities(team_set.teams, class_attributes)
 

--- a/tests/test_benchmarking/test_evaluations/test_metrics/test_cosine_similarity.py
+++ b/tests/test_benchmarking/test_evaluations/test_metrics/test_cosine_similarity.py
@@ -1,5 +1,6 @@
 import unittest
 
+from api.models.student import Student
 from api.models.team import Team
 from api.models.team_set import TeamSet
 from benchmarking.data.simulated_data.mock_student_provider import (
@@ -60,6 +61,40 @@ class TestCosineSimilarity(unittest.TestCase):
             AverageCosineSimilarity().calculate(self.team_set_distributed_attribute),
         )
 
+    def test_calculate__filters_attributes(self):
+        team_set = TeamSet(
+            teams=[
+                Team(
+                    _id=1,
+                    students=[
+                        Student(
+                            _id=1,
+                            attributes={1: [1], 2: [1]},
+                        ),
+                        Student(
+                            _id=2,
+                            attributes={1: [1], 2: [2]},
+                        ),
+                    ],
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            1, AverageCosineSimilarity(attribute_filter=[1]).calculate(team_set)
+        )
+        self.assertEqual(
+            0, AverageCosineSimilarity(attribute_filter=[2]).calculate(team_set)
+        )
+        self.assertGreater(
+            AverageCosineSimilarity(attribute_filter=[1]).calculate(team_set),
+            AverageCosineSimilarity().calculate(team_set),
+        )
+        self.assertLess(
+            AverageCosineSimilarity(attribute_filter=[2]).calculate(team_set),
+            AverageCosineSimilarity().calculate(team_set),
+        )
+
 
 class TestCosineDifference(unittest.TestCase):
     def setUp(self):
@@ -107,4 +142,38 @@ class TestCosineDifference(unittest.TestCase):
         self.assertEqual(
             0.6,
             AverageCosineDifference().calculate(self.team_set_distributed_attribute),
+        )
+
+    def test_calculate__filters_attributes(self):
+        team_set = TeamSet(
+            teams=[
+                Team(
+                    _id=1,
+                    students=[
+                        Student(
+                            _id=1,
+                            attributes={1: [1], 2: [1]},
+                        ),
+                        Student(
+                            _id=2,
+                            attributes={1: [1], 2: [2]},
+                        ),
+                    ],
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            0, AverageCosineDifference(attribute_filter=[1]).calculate(team_set)
+        )
+        self.assertEqual(
+            1, AverageCosineDifference(attribute_filter=[2]).calculate(team_set)
+        )
+        self.assertLess(
+            AverageCosineDifference(attribute_filter=[1]).calculate(team_set),
+            AverageCosineDifference().calculate(team_set),
+        )
+        self.assertGreater(
+            AverageCosineDifference(attribute_filter=[2]).calculate(team_set),
+            AverageCosineDifference().calculate(team_set),
         )


### PR DESCRIPTION
We would like to be able to measure the cosine similarity/difference of students on a filtered list of attributes. This is specifically useful in the case where we are using students with many more attributes/skills than we care about diversifying. Often we only want to measure that gender and race were diversified, and don't care about which framework they know and so don't want that affecting the score.

Closes #357 