### PR TITLE
Fix divide by zero error in cosine similarity

### DIFF
--- a/benchmarking/evaluations/metrics/cosine_similarity.py
+++ b/benchmarking/evaluations/metrics/cosine_similarity.py
@@ -90,6 +90,8 @@ def cosine_similarity(
         raise ValueError("Vectors must be the same length")
     if len(v1) == 0 or len(v2) == 0:
         raise ValueError("Vectors must not be empty")
+    if norm(v1) == 0 or norm(v2) == 0:
+        return 0
     return dot(v1, v2) / (norm(v1) * norm(v2))
 
 


### PR DESCRIPTION
This is a solution to the problem, but I'm open to other solutions. I think Seth is right with this as the solution because a student with a zero vector should be considered completely different from every other student, hence a return of 0. Other solutions online suggest using a small epsilon in the equation like `dot(v1, v2)/max(norm(v1)*norm(v2), epsilon)`, but this would cause a large value for the cosine similarity which, not only doesn't make sense in our use case, but also messes with the whole "returns a number in [0,1]"

Closes #362 