### PR TITLE
chore: move enums into relevant modules

### DIFF
--- a/api/ai/priority_algorithm/priority/priority.py
+++ b/api/ai/priority_algorithm/priority/priority.py
@@ -16,10 +16,10 @@ from api.dataclasses.enums import (
     RequirementsCriteria,
     PriorityType,
     Relationship,
+    PreferenceDirection,
 )
 from api.dataclasses.student import Student
 from api.dataclasses.team import TeamShell
-from benchmarking.evaluations.enums import PreferenceDirection
 from api.utils.math import change_range
 
 

--- a/api/dataclasses/enums.py
+++ b/api/dataclasses/enums.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List
 
 
 class Relationship(Enum):
@@ -49,78 +48,20 @@ class RequirementsCriteria(Enum):
     SOMEONE = "someone_meets_requirement"
 
 
-class ScenarioAttribute(Enum):
-    """
-    Attributes that are used in scenarios.
-    This set of attribute ids are named so that we can refer to them semantically.
-    Any attribute given to a student with an id that is not one of these can semantically mean anything,
-        please document this in your run if doing so.
-    """
-
-    GENDER = 1
-    GPA = 2
-    AGE = 3
-    RACE = 4
-    MAJOR = 5
-    YEAR_LEVEL = 6
-    TIMESLOT_AVAILABILITY = 7
-    LOCATION = 8
-
-
-class AttributeValueEnum(Enum):
-    @classmethod
-    def values(cls, integers_only=False) -> List["AttributeValueEnum"]:
-        if integers_only:
-            return [_.value for _ in cls]
-        return [_ for _ in cls]
-
-
-class Gender(AttributeValueEnum):
-    MALE = 1
-    FEMALE = 2
-    NON_BINARY = 3
-    OTHER = 4
-    NA = 5
-
-
-class Gpa(AttributeValueEnum):
-    A = 1
-    B = 2
-    C = 3
-    D = 4
-    F = 5
-
-
-class Age(AttributeValueEnum):
-    _18 = 18
-    _19 = 19
-    _20 = 20
-    _21 = 21
-
-
-class Race(AttributeValueEnum):
-    African = 1
-    European = 2
-    East_Asian = 3
-    South_Asian = 4
-    South_East_Asian = 5
-    First_Nations_or_Indigenous = 6
-    Hispanic_or_Latin_American = 7
-    Middle_Eastern = 8
-    Other = 9
-
-
-class YearLevel(AttributeValueEnum):
-    First = 1
-    Second = 2
-    Third = 3
-    Fourth = 4
-    Graduate = 5
-
-
 class PriorityType(Enum):
     TOKENIZATION = "tokenization"
     DIVERSITY = "diversity"
     PROJECT_PREFERENCE = "project_preference"
     PROJECT_REQUIREMENT = "project_requirement"
     SOCIAL_PREFERENCE = "social_preference"
+
+
+class PreferenceDirection(Enum):
+    INCLUDE = "include"
+    EXCLUDE = "exclude"
+
+
+class PreferenceSubject(Enum):
+    FRIENDS = "friends"
+    ENEMIES = "enemies"
+    PROJECTS = "projects"

--- a/benchmarking/data/interfaces.py
+++ b/benchmarking/data/interfaces.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Union, Tuple
 
-from api.dataclasses.enums import AttributeValueEnum
+from benchmarking.evaluations.enums import AttributeValueEnum
 from api.dataclasses.student import Student
 from api.dataclasses.team import TeamShell
 from api.dataclasses.team_set import TeamSet

--- a/benchmarking/data/real_data/cosc341_w2021_t2_provider/data_parser.py
+++ b/benchmarking/data/real_data/cosc341_w2021_t2_provider/data_parser.py
@@ -1,7 +1,8 @@
 import json
 from typing import List
 
-from api.dataclasses.enums import Gender, ScenarioAttribute, Relationship, YearLevel
+from api.dataclasses.enums import Relationship
+from benchmarking.evaluations.enums import Gender, ScenarioAttribute, YearLevel
 from api.dataclasses.student import Student, StudentSerializer
 from api.dataclasses.team import Team, TeamSerializer
 

--- a/benchmarking/data/real_data/cosc341_w2021_t2_provider/get_statistics.py
+++ b/benchmarking/data/real_data/cosc341_w2021_t2_provider/get_statistics.py
@@ -1,4 +1,4 @@
-from api.dataclasses.enums import ScenarioAttribute, Gender, YearLevel
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender, YearLevel
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2StudentProvider,
 )

--- a/benchmarking/data/real_data/cosc341_w2021_t2_provider/providers.py
+++ b/benchmarking/data/real_data/cosc341_w2021_t2_provider/providers.py
@@ -4,7 +4,7 @@ from typing import List
 
 import numpy as np
 
-from api.dataclasses.enums import ScenarioAttribute
+from benchmarking.evaluations.enums import ScenarioAttribute
 from api.dataclasses.student import Student, StudentSerializer
 from api.dataclasses.team import TeamSerializer, TeamShell
 from api.dataclasses.team_set import TeamSet

--- a/benchmarking/data/real_data/cosc499_s2023_provider/data_parser.py
+++ b/benchmarking/data/real_data/cosc499_s2023_provider/data_parser.py
@@ -2,10 +2,12 @@ import json
 from typing import List, Dict
 
 from api.dataclasses.enums import (
-    ScenarioAttribute,
     Relationship,
-    Gpa,
     RequirementOperator,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
+    Gpa,
 )
 from api.dataclasses.project import Project, ProjectRequirement
 from api.dataclasses.student import Student, StudentSerializer

--- a/benchmarking/data/simulated_data/mock_student_provider.py
+++ b/benchmarking/data/simulated_data/mock_student_provider.py
@@ -7,7 +7,8 @@ from typing import Literal, List, Dict
 import numpy as np
 from numpy.random import Generator
 
-from api.dataclasses.enums import Relationship, AttributeValueEnum
+from api.dataclasses.enums import Relationship
+from benchmarking.evaluations.enums import AttributeValueEnum
 from api.dataclasses.student import Student
 from benchmarking.data.interfaces import (
     StudentProvider,

--- a/benchmarking/data/simulated_data/realistic_class/providers.py
+++ b/benchmarking/data/simulated_data/realistic_class/providers.py
@@ -4,11 +4,13 @@ from typing import List
 import numpy as np
 
 from api.dataclasses.enums import (
+    RequirementOperator,
+)
+from benchmarking.evaluations.enums import (
     AttributeValueEnum,
     ScenarioAttribute,
     Gender,
     Race,
-    RequirementOperator,
 )
 from api.dataclasses.project import Project, ProjectRequirement
 from api.dataclasses.student import Student

--- a/benchmarking/evaluations/enums.py
+++ b/benchmarking/evaluations/enums.py
@@ -1,12 +1,71 @@
 from enum import Enum
+from typing import List
 
 
-class PreferenceDirection(Enum):
-    INCLUDE = "include"
-    EXCLUDE = "exclude"
+class ScenarioAttribute(Enum):
+    """
+    Attributes that are used in scenarios.
+    This set of attribute ids are named so that we can refer to them semantically.
+    Any attribute given to a student with an id that is not one of these can semantically mean anything,
+        please document this in your run if doing so.
+    """
+
+    GENDER = 1
+    GPA = 2
+    AGE = 3
+    RACE = 4
+    MAJOR = 5
+    YEAR_LEVEL = 6
+    TIMESLOT_AVAILABILITY = 7
+    LOCATION = 8
 
 
-class PreferenceSubject(Enum):
-    FRIENDS = "friends"
-    ENEMIES = "enemies"
-    PROJECTS = "projects"
+class AttributeValueEnum(Enum):
+    @classmethod
+    def values(cls, integers_only=False) -> List["AttributeValueEnum"]:
+        if integers_only:
+            return [_.value for _ in cls]
+        return [_ for _ in cls]
+
+
+class Gender(AttributeValueEnum):
+    MALE = 1
+    FEMALE = 2
+    NON_BINARY = 3
+    OTHER = 4
+    NA = 5
+
+
+class Gpa(AttributeValueEnum):
+    A = 1
+    B = 2
+    C = 3
+    D = 4
+    F = 5
+
+
+class Age(AttributeValueEnum):
+    _18 = 18
+    _19 = 19
+    _20 = 20
+    _21 = 21
+
+
+class Race(AttributeValueEnum):
+    African = 1
+    European = 2
+    East_Asian = 3
+    South_Asian = 4
+    South_East_Asian = 5
+    First_Nations_or_Indigenous = 6
+    Hispanic_or_Latin_American = 7
+    Middle_Eastern = 8
+    Other = 9
+
+
+class YearLevel(AttributeValueEnum):
+    First = 1
+    Second = 2
+    Third = 3
+    Fourth = 4
+    Graduate = 5

--- a/benchmarking/evaluations/goals.py
+++ b/benchmarking/evaluations/goals.py
@@ -1,12 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from benchmarking.evaluations.enums import (
-    PreferenceDirection,
-    PreferenceSubject,
-)
 from benchmarking.evaluations.interfaces import Goal
-from api.dataclasses.enums import DiversifyType, RequirementsCriteria
+from api.dataclasses.enums import DiversifyType, PreferenceDirection, PreferenceSubject
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
 
 

--- a/benchmarking/evaluations/metrics/average_timeslot_coverage.py
+++ b/benchmarking/evaluations/metrics/average_timeslot_coverage.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from api.dataclasses.enums import ScenarioAttribute
+from benchmarking.evaluations.enums import ScenarioAttribute
 from api.dataclasses.team_set import TeamSet
 from benchmarking.evaluations.interfaces import TeamSetMetric
 

--- a/benchmarking/evaluations/scenarios/concentrate_gpa.py
+++ b/benchmarking/evaluations/scenarios/concentrate_gpa.py
@@ -2,7 +2,8 @@ from typing import List
 
 from benchmarking.evaluations.goals import DiversityGoal, WeightGoal
 from benchmarking.evaluations.interfaces import Scenario, Goal
-from api.dataclasses.enums import DiversifyType, ScenarioAttribute
+from api.dataclasses.enums import DiversifyType
+from benchmarking.evaluations.enums import ScenarioAttribute
 
 
 class ConcentrateGPA(Scenario):

--- a/benchmarking/evaluations/scenarios/concentrate_multiple_attributes.py
+++ b/benchmarking/evaluations/scenarios/concentrate_multiple_attributes.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from api.dataclasses.enums import DiversifyType, ScenarioAttribute
+from api.dataclasses.enums import DiversifyType
+from benchmarking.evaluations.enums import ScenarioAttribute
 from benchmarking.evaluations.interfaces import Scenario, Goal
 from benchmarking.evaluations.goals import (
     DiversityGoal,

--- a/benchmarking/evaluations/scenarios/concentrate_timeslot_diversify_gender_min_2.py
+++ b/benchmarking/evaluations/scenarios/concentrate_timeslot_diversify_gender_min_2.py
@@ -2,9 +2,11 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
+    TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
     ScenarioAttribute,
     Gender,
-    TokenizationConstraintDirection,
     Race,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint

--- a/benchmarking/evaluations/scenarios/concentrate_timeslots.py
+++ b/benchmarking/evaluations/scenarios/concentrate_timeslots.py
@@ -2,6 +2,8 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
+)
+from benchmarking.evaluations.enums import (
     ScenarioAttribute,
 )
 from benchmarking.evaluations.goals import DiversityGoal

--- a/benchmarking/evaluations/scenarios/concentrate_timeslots_and_concentrate_gender_and_concentrate_race.py
+++ b/benchmarking/evaluations/scenarios/concentrate_timeslots_and_concentrate_gender_and_concentrate_race.py
@@ -2,6 +2,8 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
+)
+from benchmarking.evaluations.enums import (
     ScenarioAttribute,
     Gender,
     Race,

--- a/benchmarking/evaluations/scenarios/cosc341/concentrate_timeslot_concentrate_gender_diversify_year_level.py
+++ b/benchmarking/evaluations/scenarios/cosc341/concentrate_timeslot_concentrate_gender_diversify_year_level.py
@@ -2,6 +2,8 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
+)
+from benchmarking.evaluations.enums import (
     ScenarioAttribute,
 )
 from benchmarking.evaluations.goals import DiversityGoal, WeightGoal

--- a/benchmarking/evaluations/scenarios/cosc341/concentrate_timeslot_diversify_all_min_2_diversify_student_level.py
+++ b/benchmarking/evaluations/scenarios/cosc341/concentrate_timeslot_diversify_all_min_2_diversify_student_level.py
@@ -1,10 +1,12 @@
 from typing import List
 
 from api.dataclasses.enums import (
-    Gender,
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
+    Gender,
+    ScenarioAttribute,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
 from benchmarking.evaluations.goals import DiversityGoal, WeightGoal

--- a/benchmarking/evaluations/scenarios/cosc341/concentrate_timeslot_diversify_gender_min_2_and_diversify_year_level.py
+++ b/benchmarking/evaluations/scenarios/cosc341/concentrate_timeslot_diversify_gender_min_2_and_diversify_year_level.py
@@ -2,9 +2,11 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
+    TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
     ScenarioAttribute,
     Gender,
-    TokenizationConstraintDirection,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
 from benchmarking.evaluations.goals import WeightGoal, DiversityGoal

--- a/benchmarking/evaluations/scenarios/diversify_gender_min_2_female.py
+++ b/benchmarking/evaluations/scenarios/diversify_gender_min_2_female.py
@@ -2,8 +2,10 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
 )
 from benchmarking.evaluations.interfaces import (
     Scenario,

--- a/benchmarking/evaluations/scenarios/diversify_gender_only.py
+++ b/benchmarking/evaluations/scenarios/diversify_gender_only.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from api.dataclasses.enums import DiversifyType, ScenarioAttribute
+from api.dataclasses.enums import DiversifyType
+from benchmarking.evaluations.enums import ScenarioAttribute
 from benchmarking.evaluations.interfaces import Scenario, Goal
 from benchmarking.evaluations.goals import (
     DiversityGoal,

--- a/benchmarking/evaluations/scenarios/include_friends_exclude_enemies.py
+++ b/benchmarking/evaluations/scenarios/include_friends_exclude_enemies.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
+from api.dataclasses.enums import PreferenceDirection, PreferenceSubject
 from benchmarking.evaluations.interfaces import (
     Scenario,
     Goal,

--- a/benchmarking/evaluations/scenarios/include_social_friends.py
+++ b/benchmarking/evaluations/scenarios/include_social_friends.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
+from api.dataclasses.enums import PreferenceDirection, PreferenceSubject
 from benchmarking.evaluations.interfaces import (
     Scenario,
     Goal,

--- a/benchmarking/evaluations/scenarios/project_location.py
+++ b/benchmarking/evaluations/scenarios/project_location.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from api.dataclasses.enums import DiversifyType, ScenarioAttribute, RequirementsCriteria
+from api.dataclasses.enums import DiversifyType
+from benchmarking.evaluations.enums import ScenarioAttribute
 from benchmarking.evaluations.goals import (
     DiversityGoal,
     WeightGoal,

--- a/benchmarking/evaluations/scenarios/project_requirement_preferences_diversify_gender.py
+++ b/benchmarking/evaluations/scenarios/project_requirement_preferences_diversify_gender.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from api.dataclasses.enums import DiversifyType, ScenarioAttribute, RequirementsCriteria
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
+from api.dataclasses.enums import DiversifyType, PreferenceDirection, PreferenceSubject
+from benchmarking.evaluations.enums import ScenarioAttribute
 from benchmarking.evaluations.goals import (
     DiversityGoal,
     WeightGoal,

--- a/benchmarking/evaluations/scenarios/satisfy_project_requirements_and_diversify_female_min_of_2_and_diversify_african_min_of_2.py
+++ b/benchmarking/evaluations/scenarios/satisfy_project_requirements_and_diversify_female_min_of_2_and_diversify_african_min_of_2.py
@@ -1,10 +1,11 @@
 from typing import List
 
 from api.dataclasses.enums import (
-    RequirementsCriteria,
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
     Gender,
     Race,
 )

--- a/benchmarking/evaluations/scenarios/three_tokenization_constraints.py
+++ b/benchmarking/evaluations/scenarios/three_tokenization_constraints.py
@@ -2,8 +2,10 @@ from typing import List
 
 from api.dataclasses.enums import (
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
 from benchmarking.evaluations.goals import DiversityGoal, WeightGoal

--- a/benchmarking/runs/concentrate_gpa.py
+++ b/benchmarking/runs/concentrate_gpa.py
@@ -23,7 +23,8 @@ from benchmarking.evaluations.metrics.average_gini_index import AverageGiniIndex
 from benchmarking.evaluations.metrics.maximum_gini_index import MaximumGiniIndex
 from benchmarking.evaluations.metrics.minimum_gini_index import MinimumGiniIndex
 from benchmarking.evaluations.scenarios.concentrate_gpa import ConcentrateGPA
-from api.dataclasses.enums import ScenarioAttribute, Gpa, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gpa
 from benchmarking.runs.interfaces import Run
 from benchmarking.simulation.insight import Insight
 from benchmarking.simulation.simulation_set import SimulationSet, SimulationSetArtifact

--- a/benchmarking/runs/concentrate_many_attributes.py
+++ b/benchmarking/runs/concentrate_many_attributes.py
@@ -11,7 +11,8 @@ from api.ai.interfaces.algorithm_config import (
 )
 from api.ai.priority_algorithm.mutations.local_max import LocalMaxMutation
 from api.ai.priority_algorithm.mutations.random_swap import RandomSwapMutation
-from api.dataclasses.enums import ScenarioAttribute, Gender, Race, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender, Race
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,
     MockStudentProviderSettings,

--- a/benchmarking/runs/diversify_gender_min_2.py
+++ b/benchmarking/runs/diversify_gender_min_2.py
@@ -11,7 +11,8 @@ from api.ai.interfaces.algorithm_config import (
 )
 from api.ai.priority_algorithm.mutations.local_max import LocalMaxMutation
 from api.ai.priority_algorithm.mutations.random_swap import RandomSwapMutation
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,
     MockStudentProviderSettings,

--- a/benchmarking/runs/mutations/mutation_benchmarking.py
+++ b/benchmarking/runs/mutations/mutation_benchmarking.py
@@ -12,7 +12,8 @@ from api.ai.priority_algorithm.mutations.robinhood import RobinhoodMutation
 from api.ai.priority_algorithm.mutations.robinhood_holistic import (
     RobinhoodHolisticMutation,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, Race, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender, Race
 from benchmarking.data.simulated_data.realistic_class.providers import (
     RealisticMockInitialTeamsProvider,
     RealisticMockStudentProvider,

--- a/benchmarking/runs/mutations/mutation_benchmarking_reasonable.py
+++ b/benchmarking/runs/mutations/mutation_benchmarking_reasonable.py
@@ -12,7 +12,8 @@ from api.ai.priority_algorithm.mutations.robinhood import RobinhoodMutation
 from api.ai.priority_algorithm.mutations.robinhood_holistic import (
     RobinhoodHolisticMutation,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, Race, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender, Race
 from benchmarking.data.simulated_data.realistic_class.providers import (
     RealisticMockInitialTeamsProvider,
     RealisticMockStudentProvider,

--- a/benchmarking/runs/priority_algorithm/all_parameters/diversify_gender_min_2.py
+++ b/benchmarking/runs/priority_algorithm/all_parameters/diversify_gender_min_2.py
@@ -6,7 +6,8 @@ import typer
 from matplotlib import pyplot as plt, cm
 
 from api.ai.interfaces.algorithm_config import PriorityAlgorithmConfig
-from api.dataclasses.enums import Gender, ScenarioAttribute, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import Gender, ScenarioAttribute
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProvider,
     MockStudentProviderSettings,

--- a/benchmarking/runs/priority_algorithm/default_parameters/runtimes.py
+++ b/benchmarking/runs/priority_algorithm/default_parameters/runtimes.py
@@ -5,11 +5,13 @@ import typer
 from api.ai.interfaces.algorithm_config import PriorityAlgorithmConfig
 from api.dataclasses.enums import (
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+    AlgorithmType,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
     Gender,
     Gpa,
-    AlgorithmType,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
 from benchmarking.data.simulated_data.mock_student_provider import (
@@ -23,7 +25,6 @@ from benchmarking.evaluations.metrics.average_social_satisfied import (
 )
 from benchmarking.evaluations.metrics.priority_satisfaction import PrioritySatisfaction
 from benchmarking.evaluations.metrics.utils.team_calculations import (
-    is_strictly_happy_team_friend,
     is_happy_team_1hp_friend,
 )
 from benchmarking.evaluations.scenarios.include_social_friends import (

--- a/benchmarking/runs/priority_algorithm/diversify_gender_min_2/interfaces.py
+++ b/benchmarking/runs/priority_algorithm/diversify_gender_min_2/interfaces.py
@@ -16,7 +16,8 @@ from api.ai.priority_algorithm.mutations.robinhood import RobinhoodMutation
 from api.ai.priority_algorithm.mutations.robinhood_holistic import (
     RobinhoodHolisticMutation,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProviderSettings,
     MockStudentProvider,

--- a/benchmarking/runs/priority_algorithm/diversify_gender_min_2_lower_priority_constants/interfaces.py
+++ b/benchmarking/runs/priority_algorithm/diversify_gender_min_2_lower_priority_constants/interfaces.py
@@ -16,7 +16,8 @@ from api.ai.priority_algorithm.mutations.robinhood import RobinhoodMutation
 from api.ai.priority_algorithm.mutations.robinhood_holistic import (
     RobinhoodHolisticMutation,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProviderSettings,
     MockStudentProvider,

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/combined_run.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/combined_run.py
@@ -10,9 +10,10 @@ from api.ai.interfaces.algorithm_config import (
 from api.dataclasses.enums import (
     AlgorithmType,
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
-    RequirementsCriteria,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
     Gender,
     Age,
 )

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/custom_student_providers.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/custom_student_providers.py
@@ -3,11 +3,13 @@ from typing import List
 import numpy as np
 
 from api.dataclasses.enums import (
+    Relationship,
+)
+from benchmarking.evaluations.enums import (
     Gender,
     ScenarioAttribute,
     Gpa,
     Race,
-    Relationship,
     AttributeValueEnum,
 )
 from api.dataclasses.student import Student

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/five_diversity_constraint.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/five_diversity_constraint.py
@@ -9,10 +9,12 @@ from api.ai.interfaces.algorithm_config import (
 )
 from api.dataclasses.enums import (
     AlgorithmType,
-    Gender,
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
+    Gender,
+    ScenarioAttribute,
     Gpa,
     Race,
     Age,

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/projects_run.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/projects_run.py
@@ -9,12 +9,11 @@ from api.ai.interfaces.algorithm_config import (
     PriorityAlgorithmConfig,
     PriorityAlgorithmStartType,
 )
-from api.dataclasses.enums import RequirementsCriteria, Gpa
 from api.dataclasses.enums import (
-    ScenarioAttribute,
     RequirementOperator,
     AlgorithmType,
 )
+from benchmarking.evaluations.enums import ScenarioAttribute, Gpa
 from api.dataclasses.project import Project, ProjectRequirement
 from benchmarking.data.simulated_data.mock_initial_teams_provider import (
     MockInitialTeamsProvider,

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/social_and_diversity.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/social_and_diversity.py
@@ -10,13 +10,16 @@ from api.ai.interfaces.algorithm_config import (
 from api.dataclasses.enums import (
     AlgorithmType,
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+    PreferenceDirection,
+    PreferenceSubject,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
     Gender,
     Age,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
 from benchmarking.evaluations.goals import PreferenceGoal, WeightGoal, DiversityGoal
 from benchmarking.evaluations.interfaces import Scenario, Goal
 from benchmarking.evaluations.metrics.average_social_satisfied import (

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/social_and_project.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/social_and_project.py
@@ -15,7 +15,7 @@ from benchmarking.data.simulated_data.mock_initial_teams_provider import (
     MockInitialTeamsProvider,
     MockInitialTeamsProviderSettings,
 )
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
+from api.dataclasses.enums import PreferenceDirection, PreferenceSubject
 from benchmarking.evaluations.goals import (
     PreferenceGoal,
     WeightGoal,

--- a/benchmarking/runs/priority_algorithm/internal_parameter_exploration/triple_run.py
+++ b/benchmarking/runs/priority_algorithm/internal_parameter_exploration/triple_run.py
@@ -9,10 +9,13 @@ from api.ai.interfaces.algorithm_config import (
 )
 from api.dataclasses.enums import (
     AlgorithmType,
-    RequirementsCriteria,
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+    PreferenceDirection,
+    PreferenceSubject,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
     Gender,
     Age,
 )
@@ -21,7 +24,6 @@ from benchmarking.data.simulated_data.mock_initial_teams_provider import (
     MockInitialTeamsProvider,
     MockInitialTeamsProviderSettings,
 )
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
 from benchmarking.evaluations.goals import (
     PreferenceGoal,
     WeightGoal,

--- a/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_f2_yl.py
+++ b/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_f2_yl.py
@@ -10,7 +10,8 @@ from api.ai.interfaces.algorithm_config import (
     GroupMatcherAlgorithmConfig,
     RandomAlgorithmConfig,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2AnsweredSurveysStudentProvider,
 )

--- a/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_f2_yl_team_size_6.py
+++ b/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_f2_yl_team_size_6.py
@@ -10,7 +10,8 @@ from api.ai.interfaces.algorithm_config import (
     GroupMatcherAlgorithmConfig,
     RandomAlgorithmConfig,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2AnsweredSurveysStudentProvider,
 )

--- a/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_g2_yl.py
+++ b/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_g2_yl.py
@@ -10,7 +10,8 @@ from api.ai.interfaces.algorithm_config import (
     RandomAlgorithmConfig,
     GroupMatcherAlgorithmConfig,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2AnsweredSurveysStudentProvider,
 )

--- a/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_g2_yl_team_size_6.py
+++ b/benchmarking/runs/real_data/cosc_341/concentrate_time_diversify_g2_yl_team_size_6.py
@@ -10,7 +10,8 @@ from api.ai.interfaces.algorithm_config import (
     GroupMatcherAlgorithmConfig,
     RandomAlgorithmConfig,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2AnsweredSurveysStudentProvider,
 )

--- a/benchmarking/runs/real_data/cosc_341/concentrate_time_gender_diversify_yl.py
+++ b/benchmarking/runs/real_data/cosc_341/concentrate_time_gender_diversify_yl.py
@@ -9,7 +9,8 @@ from api.ai.interfaces.algorithm_config import (
     WeightAlgorithmConfig,
     GroupMatcherAlgorithmConfig,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2AnsweredSurveysStudentProvider,
 )

--- a/benchmarking/runs/real_data/cosc_341/concentrate_time_gender_diversify_yl_team_size_6.py
+++ b/benchmarking/runs/real_data/cosc_341/concentrate_time_gender_diversify_yl_team_size_6.py
@@ -9,7 +9,8 @@ from api.ai.interfaces.algorithm_config import (
     WeightAlgorithmConfig,
     GroupMatcherAlgorithmConfig,
 )
-from api.dataclasses.enums import ScenarioAttribute, Gender, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gender
 from benchmarking.data.real_data.cosc341_w2021_t2_provider.providers import (
     COSC341W2021T2AnsweredSurveysStudentProvider,
 )

--- a/benchmarking/runs/real_data/cosc_499/499_scenario_4.py
+++ b/benchmarking/runs/real_data/cosc_499/499_scenario_4.py
@@ -22,7 +22,7 @@ from benchmarking.data.real_data.cosc499_s2023_provider.providers import (
     COSC499S2023StudentProvider,
     COSC499S2023InitialTeamsProvider,
 )
-from benchmarking.evaluations.enums import PreferenceDirection, PreferenceSubject
+from api.dataclasses.enums import PreferenceDirection, PreferenceSubject
 from benchmarking.evaluations.goals import (
     DiversityGoal,
     WeightGoal,

--- a/benchmarking/runs/three_tokenization_constraints.py
+++ b/benchmarking/runs/three_tokenization_constraints.py
@@ -11,7 +11,8 @@ from api.ai.interfaces.algorithm_config import (
 )
 from api.ai.priority_algorithm.mutations.local_max import LocalMaxMutation
 from api.ai.priority_algorithm.mutations.random_swap import RandomSwapMutation
-from api.dataclasses.enums import ScenarioAttribute, Gpa, Age, Race, AlgorithmType
+from api.dataclasses.enums import AlgorithmType
+from benchmarking.evaluations.enums import ScenarioAttribute, Gpa, Age, Race
 from benchmarking.data.simulated_data.mock_student_provider import (
     MockStudentProviderSettings,
     MockStudentProvider,

--- a/benchmarking/simulation/goal_to_priority.py
+++ b/benchmarking/simulation/goal_to_priority.py
@@ -8,7 +8,7 @@ from api.ai.priority_algorithm.priority.priority import (
     ProjectPreferencePriority,
     SocialPreferencePriority,
 )
-from benchmarking.evaluations.enums import PreferenceSubject
+from api.dataclasses.enums import PreferenceSubject
 from benchmarking.evaluations.goals import (
     DiversityGoal,
     ProjectRequirementGoal,

--- a/benchmarking/simulation/mock_algorithm.py
+++ b/benchmarking/simulation/mock_algorithm.py
@@ -14,9 +14,9 @@ from api.dataclasses.enums import (
     AlgorithmType,
     DiversifyType,
     RelationshipBehaviour,
+    PreferenceSubject,
 )
 from api.dataclasses.team import TeamShell
-from benchmarking.evaluations.enums import PreferenceSubject
 from benchmarking.evaluations.goals import (
     WeightGoal,
     PreferenceGoal,

--- a/tests/test_api/test_ai/test_priority_algorithm/test_priority/test_priority.py
+++ b/tests/test_api/test_ai/test_priority_algorithm/test_priority/test_priority.py
@@ -11,15 +11,14 @@ from api.ai.priority_algorithm.priority.priority import (
 )
 from api.dataclasses.enums import (
     RequirementOperator,
-    RequirementsCriteria,
     DiversifyType,
     TokenizationConstraintDirection,
     Relationship,
+    PreferenceDirection,
 )
 from api.dataclasses.project import ProjectRequirement
 from api.dataclasses.student import Student
 from api.dataclasses.team import TeamShell
-from benchmarking.evaluations.enums import PreferenceDirection
 from tests.test_api.test_ai.test_priority_algorithm.test_priority._data import (
     create_social_students,
 )

--- a/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
+++ b/tests/test_benchmarking/test_data/test_simulated_data/test_mock_student_provider.py
@@ -4,7 +4,8 @@ from typing import Literal, List
 
 import numpy as np
 
-from api.dataclasses.enums import Gpa, Relationship
+from api.dataclasses.enums import Relationship
+from benchmarking.evaluations.enums import Gpa
 from api.dataclasses.student import Student
 from benchmarking.data.simulated_data.mock_student_provider import (
     create_mock_students,

--- a/tests/test_benchmarking/test_evaluations/test_metrics/test_average_solo_status.py
+++ b/tests/test_benchmarking/test_evaluations/test_metrics/test_average_solo_status.py
@@ -1,6 +1,6 @@
 import unittest
 
-from api.dataclasses.enums import ScenarioAttribute, Race, Gender
+from benchmarking.evaluations.enums import ScenarioAttribute, Race, Gender
 from api.dataclasses.student import Student
 from api.dataclasses.team import Team
 from api.dataclasses.team_set import TeamSet

--- a/tests/test_benchmarking/test_evaluations/test_metrics/test_average_timeslot_coverage.py
+++ b/tests/test_benchmarking/test_evaluations/test_metrics/test_average_timeslot_coverage.py
@@ -1,6 +1,6 @@
 import unittest
 
-from api.dataclasses.enums import ScenarioAttribute
+from benchmarking.evaluations.enums import ScenarioAttribute
 from api.dataclasses.student import Student
 from api.dataclasses.team import Team
 from api.dataclasses.team_set import TeamSet

--- a/tests/test_benchmarking/test_simulation/test_goal_to_priority.py
+++ b/tests/test_benchmarking/test_simulation/test_goal_to_priority.py
@@ -7,8 +7,10 @@ from api.ai.priority_algorithm.priority.priority import (
 )
 from api.dataclasses.enums import (
     DiversifyType,
-    ScenarioAttribute,
     TokenizationConstraintDirection,
+)
+from benchmarking.evaluations.enums import (
+    ScenarioAttribute,
 )
 from api.dataclasses.tokenization_constraint import TokenizationConstraint
 from benchmarking.evaluations.goals import DiversityGoal, WeightGoal


### PR DESCRIPTION
On a mission to get everything relevant to the algorithms in one, easily copy-able module.

The benchmarking logic should be able to be deleted without losing code critical to the actual algorithms